### PR TITLE
Adds more typing information

### DIFF
--- a/llm_compare/evaluation/classification_metrics.py
+++ b/llm_compare/evaluation/classification_metrics.py
@@ -5,12 +5,12 @@ from zeno import MetricReturn, ZenoOptions, metric
 
 
 @metric
-def accuracy(df: DataFrame, ops: ZenoOptions):
+def accuracy(df: DataFrame, ops: ZenoOptions) -> MetricReturn:
     """Calculate the accuracy of a model.
 
     Args:
-        df (pd.DataFrame): DataFrame from Zeno
-        ops (ZenoOptions): Options from Zeno
+        df: DataFrame from Zeno
+        ops: Options from Zeno
 
     Returns:
         MetricReturn: accuracy value

--- a/llm_compare/evaluation/text_features/length.py
+++ b/llm_compare/evaluation/text_features/length.py
@@ -8,8 +8,8 @@ def output_length(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
     """Length of model output.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         DistillReturn: Lengths of outputs
@@ -18,12 +18,12 @@ def output_length(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
 
 
 @distill
-def input_length(df: DataFrame, ops: ZenoOptions) -> DataFrame:
+def input_length(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
     """Length of model input.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         DistillReturn: Lengths of inputs

--- a/llm_compare/evaluation/text_metrics/critique.py
+++ b/llm_compare/evaluation/text_metrics/critique.py
@@ -9,12 +9,12 @@ client = Critique(api_key=os.environ["INSPIREDCO_API_KEY"])
 
 
 @distill
-def bert_score(df, ops):
+def bert_score(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
     """BERT score.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         DistillReturn: BERT scores
@@ -34,12 +34,12 @@ def bert_score(df, ops):
 
 
 @distill
-def bleu(df, ops):
+def bleu(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
     """BLEU score.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         DistillReturn: BLEU scores
@@ -61,12 +61,12 @@ def bleu(df, ops):
 
 
 @distill
-def chrf(df, ops):
+def chrf(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
     """CHRF score.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         DistillReturn: CHRF scores
@@ -88,12 +88,12 @@ def chrf(df, ops):
 
 
 @distill
-def length_ratio(df, ops):
+def length_ratio(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
     """Length ratio.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         DistillReturn: Length ratios
@@ -115,12 +115,12 @@ def length_ratio(df, ops):
 
 
 @distill
-def rouge(df: DataFrame, ops: ZenoOptions):
+def rouge(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
     """ROUGE score.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         DistillReturn: ROUGE scores
@@ -142,12 +142,12 @@ def rouge(df: DataFrame, ops: ZenoOptions):
 
 
 @metric
-def avg_bert_score(df, ops: ZenoOptions):
+def avg_bert_score(df: DataFrame, ops: ZenoOptions) -> MetricReturn:
     """Average BERT score.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         MetricReturn: Average BERT score
@@ -158,12 +158,12 @@ def avg_bert_score(df, ops: ZenoOptions):
 
 
 @metric
-def avg_bleu(df, ops: ZenoOptions):
+def avg_bleu(df: DataFrame, ops: ZenoOptions) -> MetricReturn:
     """Average BLEU score.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         MetricReturn: Average BLEU score
@@ -174,12 +174,12 @@ def avg_bleu(df, ops: ZenoOptions):
 
 
 @metric
-def avg_chrf(df, ops: ZenoOptions):
+def avg_chrf(df: DataFrame, ops: ZenoOptions) -> MetricReturn:
     """Average CHRF score.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         MetricReturn: Average CHRF score
@@ -190,12 +190,12 @@ def avg_chrf(df, ops: ZenoOptions):
 
 
 @metric
-def avg_length_ratio(df, ops: ZenoOptions):
+def avg_length_ratio(df: DataFrame, ops: ZenoOptions) -> MetricReturn:
     """Average length ratio.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         MetricReturn: Average length ratio
@@ -206,12 +206,12 @@ def avg_length_ratio(df, ops: ZenoOptions):
 
 
 @metric
-def avg_rouge(df, ops: ZenoOptions):
+def avg_rouge(df: DataFrame, ops: ZenoOptions) -> MetricReturn:
     """Average ROUGE score.
 
     Args:
-        df (DataFrame): Zeno DataFrame
-        ops (ZenoOptions): Zeno options
+        df: Zeno DataFrame
+        ops: Zeno options
 
     Returns:
         MetricReturn: Average ROUGE score

--- a/llm_compare/visualize.py
+++ b/llm_compare/visualize.py
@@ -1,15 +1,18 @@
 """Run Zeno to visualize the results of a parameter search run."""
 from collections.abc import Callable
 from operator import itemgetter
+from typing import Any
 
 import pandas as pd
 from zeno import ModelReturn, ZenoParameters, model, zeno
 
+from llm_compare.experiment_run import ExperimentRun
+
 
 def visualize(
     df: pd.DataFrame,
-    references,
-    results,
+    references: list[Any],
+    results: list[ExperimentRun],
     view: str,
     data_column: str,
     functions: list[Callable],
@@ -17,27 +20,25 @@ def visualize(
     """Run Zeno to visualize the results of a parameter search run.
 
     Args:
-        df (pd.DataFrame): DataFrame with the data to visualize
-        references (_type_): List of ground truth labels
-        results (_type_): List of dictionaries with model outputs
-        view (str): The Zeno view to use for the data
-        data_column (str): The column in the DataFrame with the data
-        functions (List[Callable]): List of functions to use in Zeno
+        df: DataFrame with the data to visualize
+        references: List of ground truth labels
+        results: List of dictionaries with model outputs
+        view: The Zeno view to use for the data
+        data_column: The column in the DataFrame with the data
+        functions: List of functions to use in Zeno
     """
-    model_names = []
-    model_results = {}
+    model_results: dict[str, ExperimentRun] = {}
     for res in results:
         # Hash model params to represent in Zeno. W&B uses random names.
-        name = str(hash("_".join([f"{k}={v}" for k, v in res["parameters"].items()])))
+        name = str(hash("_".join([f"{k}={v}" for k, v in res.parameters.items()])))
 
         # Prevent duplicate runs being added to Zeno
-        if name not in model_names:
-            model_names.append(name)
+        if name not in model_results:
             model_results[name] = res
 
     @model
     def get_model(name):
-        mod = model_results[name]["predictions"]
+        mod = model_results[name].predictions
 
         def pred(df, ops):
             return ModelReturn(model_output=itemgetter(*df["index"].to_list())(mod))
@@ -45,14 +46,14 @@ def visualize(
         return pred
 
     # Print a table mapping hashes to parameters.
-    for name in model_names:
-        print(name, model_results[name]["parameters"])
+    for name in model_results:
+        print(name, model_results[name].parameters)
 
     df["label"] = references
     config = ZenoParameters(
         metadata=df,
         view=view,
-        models=model_names,
+        models=list(model_results.keys()),
         functions=[get_model] + functions,
         data_column=data_column,
         label_column="label",

--- a/tasks/text_classification/main.py
+++ b/tasks/text_classification/main.py
@@ -10,6 +10,7 @@ import modeling
 from llm_compare import search_space
 from llm_compare.evaluation import classification_metrics
 from llm_compare.evaluators import accuracy
+from llm_compare.experiment_run import ExperimentRun
 from llm_compare.optimizers import standard
 from llm_compare.visualize import visualize
 
@@ -49,6 +50,7 @@ def text_classification_main(
     if os.path.exists(os.path.join(results_dir, "all_runs.json")):
         with open(os.path.join(results_dir, "all_runs.json"), "r") as f:
             serialized_results = json.load(f)
+        results = [ExperimentRun(**x) for x in serialized_results]
     else:
         evaluator = accuracy.AccuracyEvaluator(references)
         with open(os.path.join(results_dir, "references.json"), "w") as f:
@@ -56,7 +58,7 @@ def text_classification_main(
 
         # Run the hyperparameter sweep and print out results
         optimizer = standard.StandardOptimizer()
-        result = optimizer.run_sweep(
+        results = optimizer.run_sweep(
             function=modeling.train_and_predict,
             space=space,
             constants=constants,
@@ -66,7 +68,7 @@ def text_classification_main(
         )
 
         # Print out results
-        serialized_results = [asdict(x) for x in result]
+        serialized_results = [asdict(x) for x in results]
         with open(os.path.join(results_dir, "all_runs.json"), "w") as f:
             json.dump(serialized_results, f)
 
@@ -75,7 +77,7 @@ def text_classification_main(
     visualize(
         dataset,
         references,
-        serialized_results,
+        results,
         "text-classification",
         "text",
         [classification_metrics.accuracy],

--- a/tasks/text_summarization/main.py
+++ b/tasks/text_summarization/main.py
@@ -14,6 +14,7 @@ from llm_compare import search_space
 from llm_compare.evaluation.text_features.length import input_length, output_length
 from llm_compare.evaluation.text_metrics.critique import avg_rouge, rouge
 from llm_compare.evaluators import critique
+from llm_compare.experiment_run import ExperimentRun
 from llm_compare.optimizers import standard
 from llm_compare.visualize import visualize
 
@@ -70,10 +71,11 @@ def text_summarization_main(
     if os.path.exists(os.path.join(results_dir, "all_runs.json")):
         with open(os.path.join(results_dir, "all_runs.json"), "r") as f:
             serialized_results = json.load(f)
+        results = [ExperimentRun(**x) for x in serialized_results]
     else:
         # Run the hyperparameter sweep and print out results
         optimizer = standard.StandardOptimizer()
-        result = optimizer.run_sweep(
+        results = optimizer.run_sweep(
             function=modeling.make_predictions,
             space=space,
             constants=constants,
@@ -83,7 +85,7 @@ def text_summarization_main(
         )
 
         # Print out results
-        serialized_results = [asdict(x) for x in result]
+        serialized_results = [asdict(x) for x in results]
         with open(os.path.join(results_dir, "all_runs.json"), "w") as f:
             json.dump(serialized_results, f)
 
@@ -94,7 +96,7 @@ def text_summarization_main(
     visualize(
         dataset,
         [r["source"] for r in references],
-        serialized_results,
+        results,
         "text-classification",
         "article",
         [output_length, input_length, rouge, avg_rouge],


### PR DESCRIPTION
# Description

This relatively simple PR does two things:

1. More exhaustively adds typing information (to make it easier to catch errors through static analysis before runtime)
2. Removes typing information from docstrings, as it's not necessary to have it in two places, and having it duplicated can be a source of errors

# References

- In preparation for https://github.com/zeno-ml/llm-compare/issues/24

# Blocked by

- NA
