### PR TITLE
Make stripping of chatbot utterances less constrained

### DIFF
--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -226,13 +226,7 @@ def _generate_from_huggingface(
         outputs = outputs[:, encoded_prompts["input_ids"].shape[-1] :]
         results.extend(tokenizer.batch_decode(outputs, skip_special_tokens=True))
     # Post-processing to get only the system utterance
-    results = [
-        re.split(
-            rf"\n\n({model_config.name_replacements['user']}|{model_config.name_replacements['system']}|{model_config.name_replacements['assistant']}):",  # noqa: E501
-            x,
-        )[0].strip()
-        for x in results
-    ]
+    results = [re.split("\n\n", x)[0].strip() for x in results]
     return results
 
 


### PR DESCRIPTION
# Description

Previously I was only stripping chatbot utterances when it matched the pattern:

```
<newline><newline>(System|Assistant|User):
```

But the chatbots would sometimes output crazy things like
```
<newline><newline>ASSISTer:
```

This PR makes stripping just happen on two newlines to account for this.

# Blocked by

- NA

