### PR TITLE
Make readable names

### DIFF
--- a/zeno_build/experiments/experiment_run.py
+++ b/zeno_build/experiments/experiment_run.py
@@ -8,7 +8,7 @@ from typing import Any, Generic, TypeVar
 T = TypeVar("T")
 
 
-@dataclass(frozen=True)
+@dataclass
 class ExperimentRun(Generic[T]):
     """A single run of an experiment."""
 


### PR DESCRIPTION
# Description

This is an alternative attempt at model names for analysis: https://github.com/zeno-ml/zeno-build/pull/75

I had actually already implemented readable names, but they were only generated when the end-to-end process of output generation to visualization was all run without loading from the cache. This moves that code to also run when loading from the cache.

The advantage of this PR over the other one is that it's done in a more generalizable way, where it prints out all non-constant variables, and ignores constant variables.

# Blocked by

- NA