### PR TITLE
Consider OpenAI timeout error

### DIFF
--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -98,6 +98,9 @@ async def _throttled_openai_chat_completion_acreate(
                     "OpenAI API rate limit exceeded. Sleeping for 10 seconds."
                 )
                 await asyncio.sleep(10)
+            except asyncio.exceptions.TimeoutError:
+                logging.warning("OpenAI API timeout. Sleeping for 10 seconds.")
+                await asyncio.sleep(10)
             except openai.error.APIError as e:
                 logging.warning(f"OpenAI API error: {e}")
                 break


### PR DESCRIPTION
# Description

The generation code was not considering asyncio timeout errors, and the program crashed if it got one. This PR adds better handling for these errors.

# Blocked by

- NA
