### PR TITLE
pass zeno options to visualization fn

### DIFF
--- a/zeno_build/reporting/visualize.py
+++ b/zeno_build/reporting/visualize.py
@@ -16,7 +16,7 @@ def visualize(
     view: str,
     data_column: str,
     functions: list[Callable],
-    zeno_config: ZenoParameters,
+    zeno_config: ZenoParameters = ZenoParameters(),
 ) -> None:
     """Run Zeno to visualize the results of a parameter search run.
 


### PR DESCRIPTION
# Description

Instead of passing in every configuration option to the visualization function, pass in a config file that is used to override the default config. This can include options like the host, port, or whether the report is editable.