### PR TITLE
Openai utils improvements

### DIFF
--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -19,7 +19,7 @@ def generate_from_chat_prompt(
     max_tokens: int,
     top_p: float,
     context_length: int,
-    requests_per_minute: int = 50,
+    requests_per_minute: int = 300,
 ) -> list[str]:
     """Generate from a list of chat-style prompts.
 


### PR DESCRIPTION
# Description

This makes two small improvements to OpenAI utils:
1. It ups the rate limit from 50 calls/minute to 300 calls/minute by default.
2. It uses client sessions to make calls more efficient

# Blocked by

- NA