### PR TITLE
Update label of GPT3.5 as worst to best in README.md

### DIFF
--- a/examples/chatbot/report/README.md
+++ b/examples/chatbot/report/README.md
@@ -209,7 +209,7 @@ to work with.
 
 Finally, we used Zeno’s
 [exploration UI](https://zenoml.com/docs/intro#exploration-ui) to try to find
-possible errors by gpt-3.5-turbo, the worst performing model. Specifically, we
+possible errors by gpt-3.5-turbo, the best performing model. Specifically, we
 looked at all examples that had low chrf (<0.1) and looked through them manually
 to find trends.
 


### PR DESCRIPTION
Changed GPT3.5, being labeled as "worst" to "best" performing model.

<!-- EDIT THE TITLE FIRST. -->

# Description

<!-- EDIT HERE:
Write a detailed description of this change,
including backgrounds, approaches, and any other information that are related to this change.
-->

# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- Foo
- Bar
- Baz

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
- (or link to PRs)
