### PR TITLE
Add flexibility to chat history format

### DIFF
--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -100,8 +100,8 @@ def chatbot_main(
             assert param_file.endswith(".zbp")
             with open(param_file, "r") as f:
                 loaded_parameters = json.load(f)
-            with open(f"{param_file[:-4]}.jsonl", "r") as f:
-                predictions = [json.loads(x) for x in f.readlines()]
+            with open(f"{param_file[:-4]}.json", "r") as f:
+                predictions = json.load(f)
             name = reporting_utils.parameters_to_name(
                 loaded_parameters, chatbot_config.space
             )

--- a/zeno_build/evaluation/text_features/length.py
+++ b/zeno_build/evaluation/text_features/length.py
@@ -60,10 +60,13 @@ def chat_context_length(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
     """
     chat_context_lengths = []
     for data in df[ops.data_column]:
-        if not isinstance(data, ChatMessages):
+        if isinstance(data, ChatMessages):
+            chat_context_lengths.append(len(data.messages))
+        elif isinstance(data, list):
+            chat_context_lengths.append(len(data))
+        else:
             raise ValueError(
-                f"Expected {ops.data_column} column to be ChatMessages, but got "
-                f"{type(data)} instead."
+                f"Expected {ops.data_column} column to be ChatMessages, or list "
+                f"but got {type(data)} instead."
             )
-        chat_context_lengths.append(len(data.messages))
     return DistillReturn(distill_output=chat_context_lengths)


### PR DESCRIPTION
# Description

There was an issue with the chat context length calculation being used over a list instead of a ChatMessages object, which was probably introduced when fixing a bug in the display: https://github.com/zeno-ml/zeno-build/issues/122

This PR fixes the issue by allowing the feature to be calculated over either lists or ChatMessages.
It also fixes a file extension typo of "jsonl" when it should be "json".

# References

- Fixes https://github.com/zeno-ml/zeno-build/issues/122

# Blocked by

- NA
