### PR TITLE
Adjust chatbot example on re-run

### DIFF
--- a/docs/specifying_parameters.md
+++ b/docs/specifying_parameters.md
@@ -18,7 +18,7 @@ space = search_space.CombinatorialSearchSpace(
     {
         "dataset_preset": search_space.Constant("dstc11"),
         "model_preset": search_space.Categorical(
-            ["gpt2-xl", "llama-7b", "alpaca-7b", "vicuna-7b", "mpt-7b-chat"]
+            ["gpt2-xl", "llama-7b", "vicuna-7b", "mpt-7b-chat"]
         ),
         "prompt_preset": search_space.Categorical(
             ["standard", "friendly", "polite", "cynical"]

--- a/examples/chatbot/README.md
+++ b/examples/chatbot/README.md
@@ -8,7 +8,6 @@ models like
 as well as publicly available models such as
 [GPT-2](https://huggingface.co/gpt2),
 [LLaMa](https://huggingface.co/decapoda-research/llama-7b-hf),
-[Alpaca](https://huggingface.co/chavinlo/alpaca-native),
 [Vicuna](https://huggingface.co/eachadea/vicuna-7b-1.1),
 and [MPT-Chat](https://huggingface.co/mosaicml/mpt-7b-chat).
 
@@ -77,7 +76,7 @@ python main.py
 This will run ten training runs with various hyperparameters for:
 
 * `prompt_template`: four different prompts (found in [prompt_configs.py](prompt_configs.py))
-* `model`: gpt2, llama, alpaca, vicuna, mpt-chat, chatgpt, or cohere
+* `model`: gpt2, llama, vicuna, mpt-chat, chatgpt, or cohere
 * `temperature`: between 0.2, 0.3, or 0.4
 
 The results will be saved to the `results` directory, and a report of the

--- a/examples/chatbot/config.py
+++ b/examples/chatbot/config.py
@@ -28,8 +28,9 @@ from zeno_build.models.dataset_config import DatasetConfig
 from zeno_build.models.lm_config import LMConfig
 from zeno_build.prompts.chat_prompt import ChatMessages, ChatTurn
 
-# Define the space of hyperparameters to search over.
-space = search_space.CombinatorialSearchSpace(
+# Define the space of hyperparameters to search over if using
+# hyperparameter search.
+full_space = search_space.CombinatorialSearchSpace(
     {
         "dataset_preset": search_space.Constant("dstc11"),
         "model_preset": search_space.Categorical(
@@ -55,8 +56,10 @@ space = search_space.CombinatorialSearchSpace(
 )
 
 # Specifically, this is the space of hyperparameters used in the Zeno
-# chatbot report:
+# chatbot report on the DSTC11 dataset:
 # https://github.com/zeno-ml/zeno-build/tree/main/examples/chatbot
+# It can be used together with ExhaustiveOptimizer to reproduce the
+# results in the report.
 report_space = search_space.CompositeSearchSpace(
     [
         # Comparison of models

--- a/examples/chatbot/config.py
+++ b/examples/chatbot/config.py
@@ -40,7 +40,6 @@ full_space = search_space.CombinatorialSearchSpace(
                 "gpt2",
                 "gpt2-xl",
                 "llama-7b",
-                "alpaca-7b",
                 "vicuna-7b",
                 "mpt-7b-chat",
             ]
@@ -73,7 +72,6 @@ report_space = search_space.CompositeSearchSpace(
                         "gpt2",
                         "gpt2-xl",
                         "llama-7b",
-                        "alpaca-7b",
                         "vicuna-7b",
                         "mpt-7b-chat",
                     ]
@@ -153,14 +151,6 @@ model_configs = {
         provider="huggingface",
         model="decapoda-research/llama-13b-hf",
         tokenizer_cls=transformers.LlamaTokenizer,
-    ),
-    "alpaca-7b": LMConfig(
-        provider="huggingface",
-        model="chavinlo/alpaca-native",
-    ),
-    "alpaca-13b": LMConfig(
-        provider="huggingface",
-        model="chavinlo/alpaca-13b",
     ),
     "vicuna-7b": LMConfig(
         provider="huggingface",

--- a/examples/chatbot/config.py
+++ b/examples/chatbot/config.py
@@ -68,7 +68,6 @@ report_space = search_space.CompositeSearchSpace(
                 "model_preset": search_space.Categorical(
                     [
                         "gpt-3.5-turbo",
-                        # "cohere-command-xlarge",
                         "gpt2",
                         "gpt2-xl",
                         "llama-7b",
@@ -113,7 +112,7 @@ report_space = search_space.CompositeSearchSpace(
 )
 
 # The number of trials to run
-num_trials = 15
+num_trials = 13
 
 # The details of each dataset
 dataset_configs = {

--- a/examples/chatbot/config.py
+++ b/examples/chatbot/config.py
@@ -54,8 +54,65 @@ space = search_space.CombinatorialSearchSpace(
     }
 )
 
+# Specifically, this is the space of hyperparameters used in the Zeno
+# chatbot report:
+# https://github.com/zeno-ml/zeno-build/tree/main/examples/chatbot
+report_space = search_space.CompositeSearchSpace(
+    [
+        # Comparison of models
+        search_space.CombinatorialSearchSpace(
+            {
+                "dataset_preset": search_space.Constant("dstc11"),
+                "model_preset": search_space.Categorical(
+                    [
+                        "gpt-3.5-turbo",
+                        "cohere-command-xlarge",
+                        "gpt2",
+                        "gpt2-xl",
+                        "llama-7b",
+                        "alpaca-7b",
+                        "vicuna-7b",
+                        "mpt-7b-chat",
+                    ]
+                ),
+                "prompt_preset": search_space.Constant("standard"),
+                "temperature": search_space.Constant(0.3),
+                "context_length": search_space.Constant(4),
+                "max_tokens": search_space.Constant(100),
+                "top_p": search_space.Constant(1.0),
+            }
+        ),
+        # Comparison of prompts
+        search_space.CombinatorialSearchSpace(
+            {
+                "dataset_preset": search_space.Constant("dstc11"),
+                "model_preset": search_space.Constant("vicuna-7b"),
+                "prompt_preset": search_space.Categorical(
+                    ["standard", "friendly", "polite", "cynical", "insurance_standard"]
+                ),
+                "temperature": search_space.Constant(0.3),
+                "context_length": search_space.Constant(4),
+                "max_tokens": search_space.Constant(100),
+                "top_p": search_space.Constant(1.0),
+            }
+        ),
+        # Comparison of context lengths
+        search_space.CombinatorialSearchSpace(
+            {
+                "dataset_preset": search_space.Constant("dstc11"),
+                "model_preset": search_space.Constant("vicuna-7b"),
+                "prompt_preset": search_space.Constant("standard"),
+                "temperature": search_space.Constant(0.3),
+                "context_length": search_space.Discrete([1, 2, 3, 4]),
+                "max_tokens": search_space.Constant(100),
+                "top_p": search_space.Constant(1.0),
+            }
+        ),
+    ]
+)
+
 # The number of trials to run
-num_trials = 10
+num_trials = 15
 
 # The details of each dataset
 dataset_configs = {

--- a/examples/chatbot/config.py
+++ b/examples/chatbot/config.py
@@ -69,7 +69,7 @@ report_space = search_space.CompositeSearchSpace(
                 "model_preset": search_space.Categorical(
                     [
                         "gpt-3.5-turbo",
-                        "cohere-command-xlarge",
+                        # "cohere-command-xlarge",
                         "gpt2",
                         "gpt2-xl",
                         "llama-7b",

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -27,7 +27,7 @@ def chatbot_main(
 ):
     """Run the chatbot experiment."""
     # Get the dataset configuration
-    dataset_preset = chatbot_config.space.dimensions["dataset_preset"]
+    dataset_preset = chatbot_config.report_space.dimensions["dataset_preset"]
     if not isinstance(dataset_preset, search_space.Constant):
         raise ValueError("All experiments must be run on a single dataset.")
     dataset_config = chatbot_config.dataset_configs[dataset_preset.value]
@@ -57,7 +57,7 @@ def chatbot_main(
     if do_prediction:
         # Perform the hyperparameter sweep
         optimizer = standard.StandardOptimizer(
-            space=chatbot_config.space,
+            space=chatbot_config.report_space,
             distill_functions=chatbot_config.sweep_distill_functions,
             metric=chatbot_config.sweep_metric_function,
             num_trials=chatbot_config.num_trials,
@@ -88,7 +88,7 @@ def chatbot_main(
             print("***************************")
 
     if do_visualization:
-        param_files = chatbot_config.space.get_valid_param_files(
+        param_files = chatbot_config.report_space.get_valid_param_files(
             predictions_dir, include_in_progress=False
         )
         if len(param_files) < chatbot_config.num_trials:
@@ -103,7 +103,7 @@ def chatbot_main(
             with open(f"{param_file[:-4]}.json", "r") as f:
                 predictions = json.load(f)
             name = reporting_utils.parameters_to_name(
-                loaded_parameters, chatbot_config.space
+                loaded_parameters, chatbot_config.report_space
             )
             results.append(
                 ExperimentRun(

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -14,7 +14,7 @@ from examples.chatbot import config as chatbot_config
 from examples.chatbot.modeling import make_predictions, process_data
 from zeno_build.experiments import search_space
 from zeno_build.experiments.experiment_run import ExperimentRun
-from zeno_build.optimizers import standard
+from zeno_build.optimizers import exhaustive
 from zeno_build.prompts.chat_prompt import ChatMessages
 from zeno_build.reporting import reporting_utils
 from zeno_build.reporting.visualize import visualize
@@ -56,7 +56,7 @@ def chatbot_main(
 
     if do_prediction:
         # Perform the hyperparameter sweep
-        optimizer = standard.StandardOptimizer(
+        optimizer = exhaustive.ExhaustiveOptimizer(
             space=chatbot_config.report_space,
             distill_functions=chatbot_config.sweep_distill_functions,
             metric=chatbot_config.sweep_metric_function,

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -27,7 +27,7 @@ def chatbot_main(
 ):
     """Run the chatbot experiment."""
     # Get the dataset configuration
-    dataset_preset = chatbot_config.report_space.dimensions["dataset_preset"]
+    dataset_preset = chatbot_config.report_space.spaces[0].dimensions["dataset_preset"]
     if not isinstance(dataset_preset, search_space.Constant):
         raise ValueError("All experiments must be run on a single dataset.")
     dataset_config = chatbot_config.dataset_configs[dataset_preset.value]

--- a/examples/chatbot/report/README.md
+++ b/examples/chatbot/report/README.md
@@ -64,8 +64,6 @@ which includes agent-customer customer service interactions. We test 7 models:
 - **[LLaMa](https://huggingface.co/decapoda-research/llama-7b-hf):** A language
   model originally trained by Meta AI that uses a straight-up language modeling
   objective. We use the 7B model for this and all following open-source models.
-- **[Alpaca](https://huggingface.co/chavinlo/alpaca-native):** A model based on
-  LLaMa that additionally uses instruction tuning.
 - **[Vicuna](https://huggingface.co/eachadea/vicuna-7b-1.1):** A model based on
   LLaMa that is further explicitly tuned for chatbot-based applications.
 - **[MPT-Chat](https://huggingface.co/mosaicml/mpt-7b-chat):** A model trained

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
 ]
-dependencies = ["aiolimiter>=1.0.0", "inspiredco>=0.0.2", "zenoml>=0.6.0"]
+dependencies = ["aiolimiter>=1.0.0", "inspiredco>=0.0.2", "zenoml>=0.6.1"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/zeno_build/cache_utils.py
+++ b/zeno_build/cache_utils.py
@@ -64,6 +64,7 @@ class CacheLock:
     def __init__(self, filename: str):
         """Initialize the lock."""
         self.lock_path = f"{filename}.zblock"
+        self.fail_path = f"{filename}.zbfail"
         self.skipped = False
 
     def __enter__(self) -> bool:
@@ -73,7 +74,7 @@ class CacheLock:
         Otherwise, return False.
         """
         # Skip if the lock file exists
-        if os.path.exists(self.lock_path):
+        if os.path.exists(self.lock_path) or os.path.exists(self.fail_path):
             logging.getLogger(__name__).debug(f"Skipping {self.lock_path}")
             self.skipped = True
             return False

--- a/zeno_build/cache_utils.py
+++ b/zeno_build/cache_utils.py
@@ -74,19 +74,19 @@ class CacheLock:
         """
         # Skip if the lock file exists
         if os.path.exists(self.lock_path):
-            logging.getLogger(__name__).info(f"Skipping {self.lock_path}")
+            logging.getLogger(__name__).debug(f"Skipping {self.lock_path}")
             self.skipped = True
             return False
 
         # Create the lock file
         with open(self.lock_path, "w"):
-            logging.getLogger(__name__).info(f"Created lock file {self.lock_path}")
+            logging.getLogger(__name__).debug(f"Created lock file {self.lock_path}")
             pass
 
         return True
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Remove the lock file."""
-        logging.getLogger(__name__).info(f"Exiting {self.lock_path}")
         if not self.skipped:
+            logging.getLogger(__name__).debug(f"Deleting lock {self.lock_path}")
             os.remove(self.lock_path)

--- a/zeno_build/cache_utils.py
+++ b/zeno_build/cache_utils.py
@@ -63,6 +63,7 @@ class CacheLock:
     def __init__(self, filename: str):
         """Initialize the lock."""
         self.lock_path = f"{filename}.zblock"
+        self.skipped = False
 
     def __enter__(self) -> bool:
         """Enter the cache lock.
@@ -72,6 +73,7 @@ class CacheLock:
         """
         # Skip if the lock file exists
         if os.path.exists(self.lock_path):
+            self.skipped = True
             return False
 
         # Create the lock file
@@ -82,4 +84,5 @@ class CacheLock:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Remove the lock file."""
-        os.remove(self.lock_path)
+        if not self.skipped:
+            os.remove(self.lock_path)

--- a/zeno_build/cache_utils.py
+++ b/zeno_build/cache_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import pathlib
 from typing import Any
@@ -73,16 +74,19 @@ class CacheLock:
         """
         # Skip if the lock file exists
         if os.path.exists(self.lock_path):
+            logging.getLogger(__name__).info(f"Skipping {self.lock_path}")
             self.skipped = True
             return False
 
         # Create the lock file
         with open(self.lock_path, "w"):
+            logging.getLogger(__name__).info(f"Created lock file {self.lock_path}")
             pass
 
         return True
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Remove the lock file."""
+        logging.getLogger(__name__).info(f"Exiting {self.lock_path}")
         if not self.skipped:
             os.remove(self.lock_path)

--- a/zeno_build/cache_utils.py
+++ b/zeno_build/cache_utils.py
@@ -15,16 +15,37 @@ def get_cache_path(
     params: dict[str, Any],
     extension: str | None = None,
 ) -> str:
-    """Get a path to a cache.
+    """Get the path to a cache.
 
     Args:
-        task: The task to cache for.
+        cache_root: The root of the cache path.
         params: The parameters that the cache should represent.
         extension: The extension to use for the cache file, or None for no
             extension.
 
     Returns:
         The path to the cache file or directory.
+    """
+    _, cache_path = get_cache_id_and_path(cache_root, params, extension)
+    return cache_path
+
+
+def get_cache_id_and_path(
+    cache_root: str,
+    params: dict[str, Any],
+    extension: str | None = None,
+) -> tuple[str, str]:
+    """Get the ID and path to a cache.
+
+    Args:
+        cache_root: The root of the cache path.
+        params: The parameters that the cache should represent.
+        extension: The extension to use for the cache file, or None for no
+            extension.
+
+    Returns:
+        - The cache ID, which is the hash of the parameters.
+        - The path to the cache file or directory.
     """
     if extension == "zbp":
         raise ValueError(
@@ -46,7 +67,7 @@ def get_cache_path(
                 break
     with open(param_file, "w") as f:
         f.write(dumped_params)
-    return os.path.join(
+    return base_name, os.path.join(
         cache_root, base_name if extension is None else f"{base_name}.{extension}"
     )
 

--- a/zeno_build/experiments/search_space_test.py
+++ b/zeno_build/experiments/search_space_test.py
@@ -136,3 +136,33 @@ def test_get_valid_param_with_locks_and_fails():
             f"{temp_dir}/valid4.zbp",
         ]
         assert actual_output_in_progress == expected_output_in_progress
+
+
+def test_get_non_constant_dimensions_combinatorial():
+    """Test that get_non_constant_dimensions works."""
+    space = search_space.CombinatorialSearchSpace(
+        {
+            "a": search_space.Constant(1),
+            "b": search_space.Categorical([1, 2, 3]),
+            "c": search_space.Int(0, 1),
+        }
+    )
+    assert space.get_non_constant_dimensions() == ["b", "c"]
+
+
+def test_get_non_constant_dimensions_composite():
+    """Test that get_non_constant_dimensions works."""
+    space = search_space.CompositeSearchSpace(
+        [
+            search_space.CombinatorialSearchSpace(
+                {
+                    "a": search_space.Constant(1),
+                    "b": search_space.Categorical([1, 2, 3]),
+                }
+            ),
+            search_space.CombinatorialSearchSpace(
+                {"a": search_space.Constant(1), "c": search_space.Int(0, 1)}
+            ),
+        ]
+    )
+    assert space.get_non_constant_dimensions() == ["b", "c"]

--- a/zeno_build/reporting/reporting_utils.py
+++ b/zeno_build/reporting/reporting_utils.py
@@ -2,13 +2,10 @@
 
 from typing import Any
 
-from zeno_build.experiments import search_space
-from zeno_build.experiments.search_space import CombinatorialSearchSpace
+from zeno_build.experiments.search_space import SearchSpace
 
 
-def parameters_to_name(
-    parameters: dict[str, Any], space: CombinatorialSearchSpace
-) -> str:
+def parameters_to_name(parameters: dict[str, Any], space: SearchSpace) -> str:
     """Convert parameters into a readable model name.
 
     Args:
@@ -21,7 +18,6 @@ def parameters_to_name(
     return " ".join(
         [
             parameters[k] if isinstance(parameters[k], str) else f"{k}={parameters[k]}"
-            for k, v in space.dimensions.items()
-            if not isinstance(v, search_space.Constant)
+            for k in space.get_non_constant_dimensions()
         ]
     )


### PR DESCRIPTION
# Description

I re-ran the chatbot example end-to-end to re-generate data in the new file format. In doing so I discovered a variety of little issues that I resolved:

1. I implemented a search space that exactly reproduces all and only the systems in the online report using the new `CompositeSearchSpace` functionality. I also fixed a bug in creating report names when using this search space.
2. The alpaca model was throwing an error with the most recent version of transformers, and Cohere was not responding well so I removed these (for now).
3. I switched to using the ExhaustiveOptimizer to enumerate over exactly these systems.
4. I made it so that evaluation results are saved after each run so that evaluation doesn't need to be run in duplicate.
5. I bumped the version of zeno.

# Blocked by

- NA
