### PR TITLE
Add [google-cloud, gpt-3.5-turbo-0301,  gpt-4-0314] to analysis_gpt_mt

### DIFF
--- a/examples/analysis_gpt_mt/README.md
+++ b/examples/analysis_gpt_mt/README.md
@@ -54,10 +54,10 @@ INSPIREDCO_API_KEY=...
 
 ## Run the Example
 
-To run the example, first clone the GPT-MT library.
+To run the example, first clone the GPT-MT library (we clone a fork that containing more translation systems).
 
 ```bash
-git clone git@github.com:microsoft/gpt-MT.git
+git clone git@github.com:zwhe99/gpt-MT.git
 ```
 
 Then run the following command to perform evaluation and analysis:

--- a/examples/analysis_gpt_mt/README.md
+++ b/examples/analysis_gpt_mt/README.md
@@ -54,7 +54,8 @@ INSPIREDCO_API_KEY=...
 
 ## Run the Example
 
-To run the example, first clone the GPT-MT library (we clone a fork that containing more translation systems).
+To run the example, first clone the GPT-MT library (we clone a fork by
+[Zhiwei He](https://github.com/zwhe99) that contains more translation systems).
 
 ```bash
 git clone git@github.com:zwhe99/gpt-MT.git

--- a/examples/analysis_gpt_mt/config.py
+++ b/examples/analysis_gpt_mt/config.py
@@ -115,9 +115,7 @@ model_configs = {
     "gpt-3.5-turbo-0301-zeroshot": GptMtConfig(
         "gpt-3.5-turbo-0301/zeroshot", "gpt-3.5-turbo-0301", None, 0
     ),
-    "gpt-4-0314-zeroshot": GptMtConfig(
-        "gpt-4-0314/zeroshot", "gpt-4-0314", None, 0
-    ),
+    "gpt-4-0314-zeroshot": GptMtConfig("gpt-4-0314/zeroshot", "gpt-4-0314", None, 0),
 }
 
 sweep_distill_functions = [chrf]

--- a/examples/analysis_gpt_mt/config.py
+++ b/examples/analysis_gpt_mt/config.py
@@ -73,6 +73,9 @@ main_space = search_space.CombinatorialSearchSpace(
                 "text-davinci-003-zeroshot",
                 "wmt-best",
                 "MS-Translator",
+                "google-cloud",
+                "gpt-3.5-turbo-0301-zeroshot",
+                "gpt-4-0314-zeroshot",
             ]
         ),
     }
@@ -108,6 +111,13 @@ model_configs = {
     ),
     "wmt-best": GptMtConfig("wmt-best", "wmt-best"),
     "MS-Translator": GptMtConfig("MS-Translator", "MS-Translator"),
+    "google-cloud": GptMtConfig("google-cloud", "google-cloud"),
+    "gpt-3.5-turbo-0301-zeroshot": GptMtConfig(
+        "gpt-3.5-turbo-0301/zeroshot", "gpt-3.5-turbo-0301", None, 0
+    ),
+    "gpt-4-0314-zeroshot": GptMtConfig(
+        "gpt-4-0314/zeroshot", "gpt-4-0314", None, 0
+    ),
 }
 
 sweep_distill_functions = [chrf]


### PR DESCRIPTION
# Description
This PR adds system outputs of [google-cloud, gpt-3.5-turbo-0301,  gpt-4-0314] to MT analysis example. 
- I put the new system output in my fork of gpt-MT (https://github.com/zwhe99/gpt-MT).
- Add new systems in `examples/analysis_gpt_mt/config.py`
- Update the `examples/analysis_gpt_mt/README.md`

<!-- EDIT HERE:
Write a detailed description of this change,
including backgrounds, approaches, and any other information that are related to this change.
-->

# References
- #128 
- [Twitter](https://twitter.com/gneubig/status/1668626459362234376?s=20)