### PR TITLE
GPT-MT Example: Post-processing of gpt-4

### DIFF
--- a/examples/analysis_gpt_mt/config.py
+++ b/examples/analysis_gpt_mt/config.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
+from examples.analysis_gpt_mt.modeling import remove_leading_language
 from zeno_build.evaluation.text_features.capitalization import input_capital_char_ratio
 from zeno_build.evaluation.text_features.exact_match import avg_exact_match, exact_match
 from zeno_build.evaluation.text_features.frequency import output_max_word_freq
@@ -66,16 +68,17 @@ main_space = search_space.CombinatorialSearchSpace(
         "lang_pairs": search_space.Constant("all_lang_pairs"),
         "model_preset": search_space.Categorical(
             [
+                "text-davinci-003-zeroshot",
                 "text-davinci-003-RR-1-shot",
                 "text-davinci-003-RR-5-shot",
                 "text-davinci-003-QR-1-shot",
                 "text-davinci-003-QR-5-shot",
-                "text-davinci-003-zeroshot",
-                "wmt-best",
-                "MS-Translator",
-                "google-cloud",
                 "gpt-3.5-turbo-0301-zeroshot",
                 "gpt-4-0314-zeroshot",
+                "gpt-4-0314-zeroshot-postprocess",
+                "MS-Translator",
+                "google-cloud",
+                "wmt-best",
             ]
         ),
     }
@@ -90,6 +93,7 @@ class GptMtConfig:
     base_model: str
     prompt_strategy: str | None = None
     prompt_shots: int | None = None
+    post_processors: list[Callable[[str], str]] | None = None
 
 
 # The details of each model
@@ -109,13 +113,16 @@ model_configs = {
     "text-davinci-003-zeroshot": GptMtConfig(
         "text-davinci-003/zeroshot", "text-davinci-003", None, 0
     ),
-    "wmt-best": GptMtConfig("wmt-best", "wmt-best"),
-    "MS-Translator": GptMtConfig("MS-Translator", "MS-Translator"),
-    "google-cloud": GptMtConfig("google-cloud", "google-cloud"),
     "gpt-3.5-turbo-0301-zeroshot": GptMtConfig(
         "gpt-3.5-turbo-0301/zeroshot", "gpt-3.5-turbo-0301", None, 0
     ),
     "gpt-4-0314-zeroshot": GptMtConfig("gpt-4-0314/zeroshot", "gpt-4-0314", None, 0),
+    "gpt-4-0314-zeroshot-postprocess": GptMtConfig(
+        "gpt-4-0314/zeroshot", "gpt-4-0314", None, 0, [remove_leading_language]
+    ),
+    "MS-Translator": GptMtConfig("MS-Translator", "MS-Translator"),
+    "google-cloud": GptMtConfig("google-cloud", "google-cloud"),
+    "wmt-best": GptMtConfig("wmt-best", "wmt-best"),
 }
 
 sweep_distill_functions = [chrf]


### PR DESCRIPTION
# Description

This PR adds a post-processing rule for GPT-4 that removes the first word in an output when that word is a language followed by a colon. This fixes a common error pattern in GPT-4 where it tends to output the language (due to the prompt).

# Blocked by

- NA

