### PR TITLE
Add number count features

### DIFF
--- a/examples/chatbot/config.py
+++ b/examples/chatbot/config.py
@@ -15,6 +15,7 @@ from zeno_build.evaluation.text_features.length import (
     label_length,
     output_length,
 )
+from zeno_build.evaluation.text_features.numbers import english_number_count
 from zeno_build.evaluation.text_metrics.critique import (
     avg_bert_score,
     avg_chrf,
@@ -239,6 +240,7 @@ zeno_distill_and_metric_functions = [
     input_length,
     label_length,
     chat_context_length,
+    english_number_count,
     chrf,
     length_ratio,
     bert_score,

--- a/zeno_build/evaluation/text_features/numbers.py
+++ b/zeno_build/evaluation/text_features/numbers.py
@@ -1,0 +1,77 @@
+"""Length-related features."""
+from pandas import DataFrame
+from zeno import DistillReturn, ZenoOptions, distill
+
+from zeno_build.evaluation.text_tokenizers.unicode import tokenize
+
+
+@distill
+def digit_count(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
+    """Number of digits in the output.
+
+    Args:
+        df: Zeno DataFrame
+        ops: Zeno options
+
+    Returns:
+        DistillReturn: Number of digits in the output
+    """
+    return DistillReturn(distill_output=df[ops.label_column].str.count(r"[0-9]"))
+
+
+@distill
+def english_number_count(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
+    """Number of English number words in the output.
+
+    Args:
+        df: Zeno DataFrame
+        ops: Zeno options
+
+    Returns:
+        DistillReturn: Number of English number words in the output
+    """
+    english_number_words = {
+        "zero",
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+        "eleven",
+        "twelve",
+        "thirteen",
+        "fourteen",
+        "fifteen",
+        "sixteen",
+        "seventeen",
+        "eightteen",
+        "nineteen",
+        "twenty",
+        "thirty",
+        "forty",
+        "fifty",
+        "sixty",
+        "seventy",
+        "eighty",
+        "ninety",
+        "hundred",
+        "thousand",
+        "million",
+        "billion",
+        "trillion",
+        "quadrillion",
+        "quintillion",
+    }
+    number_of_numbers = [
+        sum(
+            1 if y in english_number_words else 0
+            for y in tokenize(x, merge_symbol="").split()
+        )
+        for x in df[ops.label_column]
+    ]
+    return DistillReturn(distill_output=number_of_numbers)

--- a/zeno_build/evaluation/text_features/numbers_test.py
+++ b/zeno_build/evaluation/text_features/numbers_test.py
@@ -1,0 +1,44 @@
+"""Tests for the distill functions based on sequence capitalization."""
+
+import pandas as pd
+from zeno import DistillReturn, ZenoOptions
+
+from zeno_build.evaluation.text_features.numbers import (
+    digit_count,
+    english_number_count,
+)
+
+example_df = pd.DataFrame(
+    {
+        "id": [0, 1],
+        "label": ["one, two, three", "It's as easy as 1234"],
+    }
+)
+
+
+example_ops = ZenoOptions(
+    id_column="id",
+    data_column="input",
+    label_column="label",
+    output_column="output",
+    distill_columns={},
+    data_path="",
+    label_path="",
+    output_path="",
+)
+
+
+def test_digit_count():
+    """Test the digit count function."""
+    actual_result = digit_count(example_df, example_ops)
+    expected_result = DistillReturn(distill_output=[0, 4])
+    assert isinstance(actual_result, DistillReturn)
+    assert all(expected_result.distill_output == actual_result.distill_output)
+
+
+def test_english_number_count():
+    """Test the English number count function."""
+    actual_result = english_number_count(example_df, example_ops)
+    expected_result = DistillReturn(distill_output=[3, 0])
+    assert isinstance(actual_result, DistillReturn)
+    assert expected_result.distill_output == actual_result.distill_output

--- a/zeno_build/evaluation/text_tokenizers/unicode.py
+++ b/zeno_build/evaluation/text_tokenizers/unicode.py
@@ -1,0 +1,99 @@
+# Copyright 2023 Zeno Build Team
+#
+# This is an adaption of "A simple, reversible, language-agnostic tokenizer",
+# published first in "Spell Once, Summon Anywhere: A Two-Level Open-Vocabulary
+# Language Model" ( https://arxiv.org/abs/1804.08205 ), and obtainable at
+# https://sjmielke.com/papers/tokenize/ .
+#
+# Copyright 2018 Sebastian J. Mielke
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+"""Tokenizer based on unicode character classes."""
+
+import unicodedata
+
+DEFAULT_MERGE_SYMBOL = "▁"
+
+
+def _is_weird(c):
+    return not (
+        unicodedata.category(c)[0] in "LMN" or c.isspace()
+    )  # Caution: python's isalnum(c) does not accept Marks (category M*)!
+
+
+def tokenize(
+    instring: str,
+    merge_symbol: str = DEFAULT_MERGE_SYMBOL,
+) -> str:
+    """Tokenize on unicode categories, but keep weird characters separate.
+
+    Args:
+        instring: The string to tokenize.
+        merge_symbol: The symbol to use for merges.
+
+    Returns:
+        A list of tokens.
+    """
+    # Walk through the string!
+    outsequence = []
+    for i in range(len(instring)):
+        c = instring[i]
+        c_p = instring[i - 1] if i > 0 else c
+        c_n = instring[i + 1] if i < len(instring) - 1 else c
+
+        # Is it a letter (i.e. Unicode category starts with 'L')?
+        # Or alternatively, is it just whitespace?
+        # So if it's not weird, just copy.
+        if not _is_weird(c):
+            outsequence.append(c)
+        # Otherwise it should be separated!
+        else:
+            # Was there something non-spacey before?
+            # Then we have to introduce a new space and a merge marker.
+            if not c_p.isspace():
+                outsequence.append(" " + merge_symbol)
+            # Copy character itself
+            outsequence.append(c)
+
+            # Is there something non-spacey after?
+            # Then we have to introduce a new space and a merge marker.
+            # If, however the next character would just want to merge left
+            # anyway, no need to do it now.
+            if not c_n.isspace() and not _is_weird(c_n):
+                outsequence.append(merge_symbol + " ")
+
+    return "".join(outsequence)
+
+
+def detokenize(
+    instring: str,
+    merge_symbol: str = DEFAULT_MERGE_SYMBOL,
+) -> str:
+    """Detokenize a string tokenized with tokenize()."""
+    # Walk through the string!
+    outsequence = []
+    i = 0
+    while i < len(instring):
+        c = instring[i]
+        c_n = instring[i + 1] if i < len(instring) - 1 else c
+        c_nn = instring[i + 2] if i < len(instring) - 2 else c
+
+        # It could be one of the spaces we introduced
+        if c + c_n == " " + merge_symbol and _is_weird(c_nn):
+            i += 2
+        elif _is_weird(c) and c_n + c_nn == merge_symbol + " ":
+            outsequence.append(c)
+            i += 3
+        else:
+            outsequence.append(c)
+            i += 1
+
+    return "".join(outsequence)

--- a/zeno_build/evaluation/text_tokenizers/unicode_test.py
+++ b/zeno_build/evaluation/text_tokenizers/unicode_test.py
@@ -1,0 +1,29 @@
+"""Tests of unicode tokenizer."""
+
+from zeno_build.evaluation.text_tokenizers.unicode import (
+    DEFAULT_MERGE_SYMBOL,
+    detokenize,
+    tokenize,
+)
+
+
+def test_unicode_tokenizer_basic():
+    """Test basic tokenization."""
+    dms = DEFAULT_MERGE_SYMBOL
+    assert tokenize("Hello, world!") == f"Hello {dms}, world {dms}!"
+
+
+def test_unicode_tokenizer_without_merge():
+    """Test basic tokenization without the merge character."""
+    assert tokenize("Hello, world!", merge_symbol="") == "Hello , world !"
+
+
+def test_unicode_detokenize_equal():
+    """Test detokenization.
+
+    Read in the current file and make sure that each line detokenizes to itself.
+    """
+    with open(__file__, "r") as f:
+        for line in f:
+            if "▁" not in line:
+                assert detokenize(tokenize(line)) == line


### PR DESCRIPTION
# Description

This PR:
1. Adds a tokenizer to tokenize text into words
2. Adds a feature the counts number words in English and digits
3. Adds the number count feature to the chatbot example

The motivation for this is that there are a lot of number-based utterances in the chatbot example, and the feature could uncover interesting patterns.

# Blocked by

- NA
