### PR TITLE
Cluster features

### DIFF
--- a/examples/chatbot/config.py
+++ b/examples/chatbot/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import transformers
 
+from zeno_build.evaluation.text_features.clustering import label_clusters
 from zeno_build.evaluation.text_features.exact_match import avg_exact_match, exact_match
 from zeno_build.evaluation.text_features.length import (
     chat_context_length,
@@ -241,6 +242,7 @@ zeno_distill_and_metric_functions = [
     label_length,
     chat_context_length,
     english_number_count,
+    label_clusters,
     chrf,
     length_ratio,
     bert_score,

--- a/zeno_build/evaluation/text_features/clustering.py
+++ b/zeno_build/evaluation/text_features/clustering.py
@@ -10,7 +10,7 @@ def _cluster_docs(
     documents: list[str],
     num_clusters: int,
     model_name: str,
-) -> list[int]:
+) -> list[str]:
     try:
         from sentence_transformers import SentenceTransformer
     except ImportError:
@@ -29,7 +29,7 @@ def _cluster_docs(
     kmeans.fit(document_embeddings)
 
     # Get the cluster number for each document
-    return kmeans.labels_.tolist()
+    return [f"C{x}" for x in kmeans.labels_.tolist()]
 
 
 @distill

--- a/zeno_build/evaluation/text_features/clustering.py
+++ b/zeno_build/evaluation/text_features/clustering.py
@@ -1,9 +1,7 @@
 """Features related to clustering of text data."""
 import math
 
-import numpy as np
 from pandas import DataFrame
-from sentence_transformers import SentenceTransformer
 from sklearn.cluster import KMeans
 from zeno import DistillReturn, ZenoOptions, distill
 
@@ -12,7 +10,14 @@ def _cluster_docs(
     documents: list[str],
     num_clusters: int,
     model_name: str,
-) -> np.ndarray:
+) -> list[int]:
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError:
+        raise ImportError(
+            "Please install sentence-transformers to use clustering features."
+        )
+
     # Load the model. Models are downloaded automatically if not present
     model = SentenceTransformer(model_name)
 
@@ -24,7 +29,7 @@ def _cluster_docs(
     kmeans.fit(document_embeddings)
 
     # Get the cluster number for each document
-    return kmeans.labels_
+    return kmeans.labels_.tolist()
 
 
 @distill

--- a/zeno_build/evaluation/text_features/clustering.py
+++ b/zeno_build/evaluation/text_features/clustering.py
@@ -1,0 +1,61 @@
+"""Features related to clustering of text data."""
+import math
+
+import numpy as np
+from pandas import DataFrame
+from sentence_transformers import SentenceTransformer
+from sklearn.cluster import KMeans
+from zeno import DistillReturn, ZenoOptions, distill
+
+
+def _cluster_docs(
+    documents: list[str],
+    num_clusters: int,
+    model_name: str,
+) -> np.ndarray:
+    # Load the model. Models are downloaded automatically if not present
+    model = SentenceTransformer(model_name)
+
+    # Encode the documents to get their embeddings
+    document_embeddings = model.encode(documents)
+
+    # Perform kmeans clustering
+    kmeans = KMeans(n_clusters=num_clusters)
+    kmeans.fit(document_embeddings)
+
+    # Get the cluster number for each document
+    return kmeans.labels_
+
+
+@distill
+def data_clusters(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
+    """Cluster the labels together to find similar sentences.
+
+    Args:
+        df: Zeno DataFrame
+        ops: Zeno options
+
+    Returns:
+        DistillReturn: Number of digits in the output
+    """
+    documents = [str(x) for x in df[ops.data_column]]
+    num_clusters = int(math.sqrt(len(documents)))
+    document_clusters = _cluster_docs(documents, num_clusters, "all-MiniLM-L6-v2")
+    return DistillReturn(distill_output=document_clusters)
+
+
+@distill
+def label_clusters(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
+    """Cluster the labels together to find similar sentences.
+
+    Args:
+        df: Zeno DataFrame
+        ops: Zeno options
+
+    Returns:
+        DistillReturn: Number of digits in the output
+    """
+    documents = [str(x) for x in df[ops.label_column]]
+    num_clusters = int(math.sqrt(len(documents)))
+    document_clusters = _cluster_docs(documents, num_clusters, "all-MiniLM-L6-v2")
+    return DistillReturn(distill_output=document_clusters)

--- a/zeno_build/evaluation/text_features/clustering.py
+++ b/zeno_build/evaluation/text_features/clustering.py
@@ -1,6 +1,4 @@
 """Features related to clustering of text data."""
-import math
-
 from pandas import DataFrame
 from sklearn.cluster import KMeans
 from zeno import DistillReturn, ZenoOptions, distill
@@ -44,7 +42,11 @@ def data_clusters(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
         DistillReturn: Number of digits in the output
     """
     documents = [str(x) for x in df[ops.data_column]]
-    num_clusters = int(math.sqrt(len(documents)))
+    # TODO(gneubig): having something like the sqrt of the number of documents seems
+    #   like a good number of clusters, but more than 20 are not supported in Zeno:
+    #   https://github.com/zeno-ml/zeno/issues/873
+    # num_clusters = int(math.sqrt(len(documents)))
+    num_clusters = 20
     document_clusters = _cluster_docs(documents, num_clusters, "all-MiniLM-L6-v2")
     return DistillReturn(distill_output=document_clusters)
 
@@ -61,6 +63,10 @@ def label_clusters(df: DataFrame, ops: ZenoOptions) -> DistillReturn:
         DistillReturn: Number of digits in the output
     """
     documents = [str(x) for x in df[ops.label_column]]
-    num_clusters = int(math.sqrt(len(documents)))
+    # TODO(gneubig): having something like the sqrt of the number of documents seems
+    #   like a good number of clusters, but more than 20 are not supported in Zeno:
+    #   https://github.com/zeno-ml/zeno/issues/873
+    # num_clusters = int(math.sqrt(len(documents)))
+    num_clusters = 20
     document_clusters = _cluster_docs(documents, num_clusters, "all-MiniLM-L6-v2")
     return DistillReturn(distill_output=document_clusters)

--- a/zeno_build/reporting/visualize.py
+++ b/zeno_build/reporting/visualize.py
@@ -57,7 +57,7 @@ def visualize(
         data_column=data_column,
         label_column="label",
         batch_size=100000,
-        # multiprocessing=False,
+        multiprocessing=False,
     )
     config = config.copy(update=zeno_config)
 


### PR DESCRIPTION
# Description

This PR adds the ability to calculate features based on clusters of SentenceBERT embeddings.
This could be useful for finding salient features of text to slice along automatically (if the clusters are sufficiently good).

I have a technical question though. For some reason, it seems that these features are being recognized as standard text and appear in the explorer like this:

<img width="324" alt="Screen Shot 2023-06-23 at 2 23 46 AM" src="https://github.com/zeno-ml/zeno-build/assets/398875/59af05f0-39ef-4575-9cef-c1815402b56b">

They also aren't accessible through slice finder.

In contrast, some other categorical features like `lang_pair` in the [translation example](https://zeno-ml-translation-report.hf.space/) seem to be recognized and displayed differently:

<img width="358" alt="Screen Shot 2023-06-23 at 2 23 34 AM" src="https://github.com/zeno-ml/zeno-build/assets/398875/0638efde-c656-45fc-85f5-3f65291dea94">

[Here](https://github.com/zeno-ml/zeno-build/blob/5c36d2bdde2f57b1b537e868f1a96671a181cd65/examples/analysis_gpt_mt/main.py#L59) is the code for calculating those.

Do you know if there is a way that I can get the cluster features to be recognized in the same way so they can be treated as categorical features and used in slice finder?

# References

- Fixes https://github.com/zeno-ml/zeno-build/issues/149

# Blocked by

- NA
