### PR TITLE
fix: relative imports for examples and init.py for tokenization

### DIFF
--- a/examples/analysis_gpt_mt/config.py
+++ b/examples/analysis_gpt_mt/config.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from examples.analysis_gpt_mt.modeling import remove_leading_language
+from modeling import remove_leading_language
+
 from zeno_build.evaluation.text_features.capitalization import input_capital_char_ratio
 from zeno_build.evaluation.text_features.exact_match import avg_exact_match, exact_match
 from zeno_build.evaluation.text_features.frequency import output_max_word_freq

--- a/examples/analysis_gpt_mt/main.py
+++ b/examples/analysis_gpt_mt/main.py
@@ -5,14 +5,10 @@ from __future__ import annotations
 import argparse
 import os
 
+import config
 import pandas as pd
+from modeling import GptMtInstance, process_data, process_output
 
-from examples.analysis_gpt_mt import config
-from examples.analysis_gpt_mt.modeling import (
-    GptMtInstance,
-    process_data,
-    process_output,
-)
 from zeno_build.experiments import search_space
 from zeno_build.experiments.experiment_run import ExperimentRun
 from zeno_build.reporting.visualize import visualize

--- a/examples/analysis_gpt_mt/modeling.py
+++ b/examples/analysis_gpt_mt/modeling.py
@@ -5,7 +5,7 @@ import os
 import re
 from dataclasses import dataclass
 
-from examples.analysis_gpt_mt import config
+import config
 
 
 @dataclass(frozen=True)

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -8,10 +8,10 @@ import logging
 import os
 from dataclasses import asdict
 
+import config as chatbot_config
 import pandas as pd
+from modeling import make_predictions, process_data
 
-from examples.chatbot import config as chatbot_config
-from examples.chatbot.modeling import make_predictions, process_data
 from zeno_build.experiments import search_space
 from zeno_build.experiments.experiment_run import ExperimentRun
 from zeno_build.optimizers import exhaustive

--- a/examples/chatbot/modeling.py
+++ b/examples/chatbot/modeling.py
@@ -8,9 +8,9 @@ import traceback
 from collections.abc import Iterable
 from typing import Literal
 
+import config as chatbot_config
 import datasets
 
-from examples.chatbot import config as chatbot_config
 from zeno_build.cache_utils import (
     CacheLock,
     fail_cache,

--- a/examples/code_generation/main.py
+++ b/examples/code_generation/main.py
@@ -7,10 +7,10 @@ import json
 import logging
 import os
 
+import config as codegen_config
 import pandas as pd
+from modeling import make_predictions, process_data
 
-from examples.code_generation import config as codegen_config
-from examples.code_generation.modeling import make_predictions, process_data
 from zeno_build.experiments import search_space
 from zeno_build.experiments.experiment_run import ExperimentRun
 from zeno_build.optimizers import standard

--- a/examples/code_generation/modeling.py
+++ b/examples/code_generation/modeling.py
@@ -6,9 +6,9 @@ import json
 import os
 import traceback
 
+import config as codegen_config
 import datasets
 
-from examples.code_generation import config as codegen_config
 from zeno_build.cache_utils import (
     CacheLock,
     fail_cache,

--- a/examples/summarization/main.py
+++ b/examples/summarization/main.py
@@ -7,10 +7,10 @@ import json
 import logging
 import os
 
+import config as summarization_config
 import pandas as pd
+from modeling import load_data, make_predictions
 
-from examples.summarization import config as summarization_config
-from examples.summarization.modeling import load_data, make_predictions
 from zeno_build.experiments import search_space
 from zeno_build.experiments.experiment_run import ExperimentRun
 from zeno_build.optimizers import standard

--- a/examples/summarization/modeling.py
+++ b/examples/summarization/modeling.py
@@ -7,9 +7,9 @@ import hashlib
 import json
 import os
 
+import config as summarization_config
 import datasets
 
-from examples.summarization import config as summarization_config
 from zeno_build.cache_utils import get_cache_path
 from zeno_build.models.text_generate import generate_from_text_prompt
 

--- a/examples/text_classification/main.py
+++ b/examples/text_classification/main.py
@@ -7,11 +7,11 @@ import json
 import logging
 import os
 
+import config as text_classification_config
 import datasets
 import pandas as pd
+from modeling import load_data, train_and_predict
 
-from examples.text_classification import config as text_classification_config
-from examples.text_classification.modeling import load_data, train_and_predict
 from zeno_build.experiments import search_space
 from zeno_build.experiments.experiment_run import ExperimentRun
 from zeno_build.optimizers import standard

--- a/examples/text_classification/modeling.py
+++ b/examples/text_classification/modeling.py
@@ -7,10 +7,10 @@ import os
 import traceback
 from collections.abc import Sequence
 
+import config as text_classification_config
 import datasets
 import transformers
 
-from examples.text_classification import config as text_classification_config
 from zeno_build.cache_utils import CacheLock, fail_cache, get_cache_path
 
 

--- a/examples/transcription/main.py
+++ b/examples/transcription/main.py
@@ -7,10 +7,10 @@ import json
 import logging
 import os
 
+import config as transcription_config
 import pandas as pd
+from modeling import get_audio_paths, make_predictions
 
-import examples.transcription.config as transcription_config
-from examples.transcription.modeling import get_audio_paths, make_predictions
 from zeno_build.experiments.experiment_run import ExperimentRun
 from zeno_build.optimizers import exhaustive
 from zeno_build.reporting import reporting_utils

--- a/zeno_build/evaluation/text_tokenizers/__init__.py
+++ b/zeno_build/evaluation/text_tokenizers/__init__.py
@@ -1,0 +1,1 @@
+"""Functions for tokenizing text."""


### PR DESCRIPTION
Fix Examples

# Description

When running the example, the python imports were not working correctly. This has been fixed by changing imports within one example to be relative and adding a init.py to the tokenization module.
