### PR TITLE
Make chatbot example configurable

### DIFF
--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--single-model",
         type=str,
-        default=None,
+        default=chatbot_config.default_single_model,
         help="The model to use (for experimental settings with a single model).",
     )
     parser.add_argument(
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--single-prompt",
         type=str,
-        default=None,
+        default=chatbot_config.default_single_prompt,
         help="The prompt to use (for experimental settings with a single prompt).",
     )
     parser.add_argument(

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -138,9 +138,7 @@ def chatbot_main(
                 loaded_parameters = json.load(f)
             with open(f"{param_file[:-4]}.json", "r") as f:
                 predictions = json.load(f)
-            name = reporting_utils.parameters_to_name(
-                loaded_parameters, chatbot_config.report_space
-            )
+            name = reporting_utils.parameters_to_name(loaded_parameters, my_space)
             results.append(
                 ExperimentRun(
                     parameters=loaded_parameters, predictions=predictions, name=name

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -114,7 +114,7 @@ def chatbot_main(
             print("***************************")
 
     if do_visualization:
-        param_files = chatbot_config.report_space.get_valid_param_files(
+        param_files = my_space.get_valid_param_files(
             predictions_dir, include_in_progress=False
         )
         if len(param_files) < chatbot_config.num_trials:

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -24,7 +24,9 @@ from zeno_build.reporting.visualize import visualize
 
 def chatbot_main(
     models: list[str],
+    single_model: str,
     prompts: list[str],
+    single_prompt: str,
     experiments: list[str],
     hf_inference_method: str,
     results_dir: str,
@@ -39,8 +41,16 @@ def chatbot_main(
     for setting in experiment_settings:
         if isinstance(setting.dimensions["model_preset"], search_space.Categorical):
             setting.dimensions["model_preset"] = search_space.Categorical(models)
+        else:
+            assert isinstance(setting.dimensions["model_preset"], search_space.Constant)
+            setting.dimensions["model_preset"] = search_space.Constant(single_model)
         if isinstance(setting.dimensions["prompt_preset"], search_space.Categorical):
             setting.dimensions["prompt_preset"] = search_space.Categorical(prompts)
+        else:
+            assert isinstance(
+                setting.dimensions["prompt_preset"], search_space.Constant
+            )
+            setting.dimensions["prompt_preset"] = search_space.Constant(single_prompt)
     my_space = search_space.CompositeSearchSpace(
         cast(list[search_space.SearchSpace], experiment_settings)
     )
@@ -166,11 +176,23 @@ if __name__ == "__main__":
         help="The models to use (for experimental settings with multiple models).",
     )
     parser.add_argument(
+        "--single-model",
+        type=str,
+        default=None,
+        help="The model to use (for experimental settings with a single model).",
+    )
+    parser.add_argument(
         "--prompts",
         type=str,
         nargs="+",
         default=chatbot_config.default_prompts,
         help="The prompts to use (for experimental settings with multiple prompts).",
+    )
+    parser.add_argument(
+        "--single-prompt",
+        type=str,
+        default=None,
+        help="The prompt to use (for experimental settings with a single prompt).",
     )
     parser.add_argument(
         "--experiments",
@@ -211,7 +233,9 @@ if __name__ == "__main__":
 
     chatbot_main(
         models=args.models,
+        single_model=args.single_model,
         prompts=args.prompts,
+        single_prompt=args.single_prompt,
         experiments=args.experiments,
         hf_inference_method=args.hf_inference_method,
         results_dir=args.results_dir,

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -117,7 +117,7 @@ def chatbot_main(
         param_files = my_space.get_valid_param_files(
             predictions_dir, include_in_progress=False
         )
-        if len(param_files) < chatbot_config.num_trials:
+        if chatbot_config.num_trials and len(param_files) < chatbot_config.num_trials:
             logging.getLogger().warning(
                 "Not enough completed but performing visualization anyway."
             )

--- a/examples/chatbot/modeling.py
+++ b/examples/chatbot/modeling.py
@@ -1,6 +1,7 @@
 """Chatbots using API-based services."""
 from __future__ import annotations
 
+import dataclasses
 import itertools
 import json
 import os
@@ -131,7 +132,6 @@ def process_data(
 
 def make_predictions(
     contexts: list[ChatMessages],
-    dataset_preset: str,
     prompt_preset: str,
     model_preset: str,
     temperature: float = 0.3,
@@ -139,13 +139,12 @@ def make_predictions(
     top_p: float = 1,
     context_length: int = -1,
     output_dir: str = "results",
+    hf_inference_method: str = "huggingface",
 ) -> tuple[str, list[str]] | None:
     """Make predictions over a particular dataset.
 
     Args:
         contexts: The previous chat contexts to generate from.
-        dataset_preset: The name of the dataset to use (solely for the purpose)
-            of recording in the system output parameters.
         prompt_preset: The prompt to use for the API call.
         model_preset: The model to use for the API call.
         temperature: The temperature to use for sampling.
@@ -154,6 +153,8 @@ def make_predictions(
         context_length: The maximum length of the context to use. If 0,
             use the full context.
         output_dir: The location of the cache directory if any
+        hf_inference_method: The inference method to use for Hugging Face models.
+            This can be huggingface or vllm.
 
     Side effects:
         - Saves the predictions in a '.json' file in the `output_dir` directory
@@ -179,10 +180,15 @@ def make_predictions(
             return None
         # Make predictions
         try:
+            # Set the inference method for huggingface models
+            my_model = chatbot_config.model_configs[model_preset]
+            if my_model.provider == "huggingface":
+                my_model = dataclasses.replace(my_model, provider=hf_inference_method)
+            # Generate from the chat prompt
             predictions: list[str] = generate_from_chat_prompt(
                 contexts,
                 chatbot_config.prompt_messages[prompt_preset],
-                chatbot_config.model_configs[model_preset],
+                my_model,
                 temperature,
                 max_tokens,
                 top_p,

--- a/examples/chatbot/modeling.py
+++ b/examples/chatbot/modeling.py
@@ -166,7 +166,9 @@ def make_predictions(
     """
     # Load from cache if existing
     parameters = {
-        k: v for k, v in locals().items() if k not in {"contexts", "output_dir"}
+        k: v
+        for k, v in locals().items()
+        if k not in {"contexts", "output_dir", "hf_inference_method"}
     }
     system_id, file_root = get_cache_id_and_path(output_dir, parameters)
     if os.path.exists(f"{file_root}.json"):

--- a/examples/chatbot/requirements.txt
+++ b/examples/chatbot/requirements.txt
@@ -1,9 +1,6 @@
-cohere
 datasets
 einops
-openai
 protobuf==3.20.0
 sentencepiece
 transformers
 torch
-vllm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
 ]
-dependencies = ["aiolimiter>=1.0.0", "inspiredco>=0.0.2", "zenoml>=0.6.1"]
+dependencies = [
+  "aiolimiter>=1.0.0",
+  "inspiredco>=0.0.2",
+  "openai>=0.27.0",
+  "zenoml>=0.6.1",
+]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/zeno_build/models/global_models.py
+++ b/zeno_build/models/global_models.py
@@ -1,7 +1,3 @@
 """A module for global variables regarding models."""
 
-from __future__ import annotations
-
-import cohere
-
-cohere_client: cohere.Client | None = None
+cohere_client = None

--- a/zeno_build/models/providers/cohere_utils.py
+++ b/zeno_build/models/providers/cohere_utils.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 import aiolimiter
-import cohere
 from tqdm.asyncio import tqdm_asyncio
 
 from zeno_build.models import global_models, lm_config
@@ -18,6 +17,12 @@ async def _throttled_cohere_acreate(
     top_p: float,
     limiter: aiolimiter.AsyncLimiter,
 ) -> str:
+    try:
+        import cohere
+    except ImportError:
+        raise ImportError(
+            "Please `pip install cohere` to perform cohere-based inference"
+        )
     async with limiter:
         assert global_models.cohere_client is not None
         try:
@@ -68,6 +73,12 @@ async def generate_from_cohere(
         raise ValueError(
             "COHERE_API_KEY environment variable must be set when using the "
             "Cohere API."
+        )
+    try:
+        import cohere
+    except ImportError:
+        raise ImportError(
+            "Please `pip install cohere` to perform cohere-based inference"
         )
     global_models.cohere_client = cohere.Client(os.environ["COHERE_API_KEY"])
     limiter = aiolimiter.AsyncLimiter(requests_per_minute)

--- a/zeno_build/models/providers/vllm_utils.py
+++ b/zeno_build/models/providers/vllm_utils.py
@@ -68,7 +68,10 @@ def generate_from_vllm(
     # Process in batches
     results = llm.generate(filled_prompts, sampling_params)
     # Post-processing to get only the system utterance
-    results = [re.split("\n\n", x.outputs[0].text)[0].strip() for x in results]
+    results = [
+        re.split("\n\n", x.outputs[0].text)[0].replace("</s>", "").strip()
+        for x in results
+    ]
     return results
 
 
@@ -111,5 +114,8 @@ def text_generate_from_vllm(
     # Process in batches
     results = llm.generate(filled_prompts, sampling_params)
     # Post-processing to get only the system utterance
-    results = [re.split("\n\n", x.outputs[0].text)[0].strip() for x in results]
+    results = [
+        re.split("\n\n", x.outputs[0].text)[0].replace("</s>", "").strip()
+        for x in results
+    ]
     return results


### PR DESCRIPTION
# Description

This PR organizes the configuration file for the chatbot example into sections, and makes several elements configurable through command line options:

- Which experiments to run (i.e. what parameters to sweep over)
- What models to use
- What prompts to use
- What inference method to use for open-source models (huggingface or vllm)

It also makes a few related changes

- Organizes imported libraries to make openai required (since it's pretty standard anyway), and remove the requirement for cohere if cohere models are not used.

I have re-run experiments using this and things seem to be working OK.

# References

- Fixes https://github.com/zeno-ml/zeno-build/issues/160

# Blocked by

- NA
