### PR TITLE
Sort model names before display

### DIFF
--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -144,6 +144,7 @@ def chatbot_main(
                     parameters=loaded_parameters, predictions=predictions, name=name
                 )
             )
+        results.sort(key=lambda x: x.name)
 
         # Perform the visualization
         df = pd.DataFrame(

--- a/examples/code_generation/main.py
+++ b/examples/code_generation/main.py
@@ -110,6 +110,7 @@ def codegen_main(
                     parameters=loaded_parameters, predictions=predictions, name=name
                 )
             )
+        results.sort(key=lambda x: x.name)
 
         # Perform the visualization
         df = pd.DataFrame(

--- a/examples/summarization/main.py
+++ b/examples/summarization/main.py
@@ -104,6 +104,7 @@ def summarization_main(
                     parameters=loaded_parameters, predictions=predictions, name=name
                 )
             )
+        results.sort(key=lambda x: x.name)
 
         # Perform the visualization
         df = pd.DataFrame(

--- a/examples/text_classification/main.py
+++ b/examples/text_classification/main.py
@@ -108,6 +108,7 @@ def text_classification_main(
                     parameters=loaded_parameters, predictions=predictions, name=name
                 )
             )
+        results.sort(key=lambda x: x.name)
 
         # Perform the visualization
         df = pd.DataFrame(


### PR DESCRIPTION
# Description

Model names were not sorted before displaying them, which led them being in unpredictable order. This PR fixes this.

# Blocked by

- NA
