### PR TITLE
Refactor `chat_generate`

### DIFF
--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -57,6 +57,7 @@ def generate_from_chat_prompt(
         f"{temperature=}, {max_tokens=}, {top_p=}, {context_length=}..."
     )
     if model_config.provider == "openai":
+        response_per_api_call = 1
         return asyncio.run(
             generate_from_openai_completion(
                 _contexts_to_prompts(
@@ -65,11 +66,13 @@ def generate_from_chat_prompt(
                 model_config,
                 temperature,
                 max_tokens,
+                response_per_api_call,
                 top_p,
                 requests_per_minute,
             )
         )
     elif model_config.provider == "openai_chat":
+        response_per_api_call = 1
         return asyncio.run(
             generate_from_openai_chat_completion(
                 full_contexts,
@@ -77,6 +80,7 @@ def generate_from_chat_prompt(
                 model_config,
                 temperature,
                 max_tokens,
+                response_per_api_call,
                 top_p,
                 context_length,
                 requests_per_minute,

--- a/zeno_build/models/providers/openai_utils.py
+++ b/zeno_build/models/providers/openai_utils.py
@@ -121,7 +121,6 @@ async def _throttled_openai_chat_completion_acreate(
     top_p: float,
     limiter: aiolimiter.AsyncLimiter,
 ) -> dict[str, Any]:
-    # This function is modified from https://github.com/zeno-ml/zeno-build/blob/main/zeno_build/models/providers/openai_utils.py # noqa E501
     async with limiter:
         for _ in range(3):
             try:

--- a/zeno_build/models/providers/openai_utils.py
+++ b/zeno_build/models/providers/openai_utils.py
@@ -7,12 +7,21 @@ from typing import Any
 
 import aiolimiter
 import openai
-import openai.error
 from aiohttp import ClientSession
+from openai import error
 from tqdm.asyncio import tqdm_asyncio
 
 from zeno_build.models import lm_config
 from zeno_build.prompts import chat_prompt
+
+ERROR_ERRORS_TO_MESSAGES = {
+    error.InvalidRequestError: "OpenAI API Invalid Request: Prompt was filtered",
+    error.RateLimitError: "OpenAI API rate limit exceeded. Sleeping for 10 seconds.",
+    error.APIConnectionError: "OpenAI API Connection Error: Error Communicating with OpenAI",  # noqa E501
+    error.Timeout: "OpenAI APITimeout Error: OpenAI Timeout",
+    error.ServiceUnavailableError: "OpenAI service unavailable error: {e}",
+    error.APIError: "OpenAI API error: {e}",
+}
 
 
 async def _throttled_openai_completion_acreate(
@@ -20,6 +29,7 @@ async def _throttled_openai_completion_acreate(
     prompt: str,
     temperature: float,
     max_tokens: int,
+    n: int,
     top_p: float,
     limiter: aiolimiter.AsyncLimiter,
 ) -> dict[str, Any]:
@@ -31,36 +41,25 @@ async def _throttled_openai_completion_acreate(
                     prompt=prompt,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    n=n,
                     top_p=top_p,
                 )
-            except openai.error.RateLimitError:
-                logging.warning(
-                    "OpenAI API rate limit exceeded. Sleeping for 10 seconds."
-                )
-                await asyncio.sleep(10)
-            except asyncio.exceptions.TimeoutError:
-                logging.warning("OpenAI API timeout. Sleeping for 10 seconds.")
-                await asyncio.sleep(10)
-            except openai.error.InvalidRequestError:
-                logging.warning("OpenAI API Invalid Request: Prompt was filtered")
-                return {
-                    "choices": [
-                        {"message": {"content": "Invalid Request: Prompt was filtered"}}
-                    ]
-                }
-            except openai.error.APIConnectionError:
-                logging.warning(
-                    "OpenAI API Connection Error: Error Communicating with OpenAI"
-                )
-                await asyncio.sleep(10)
-            except openai.error.Timeout:
-                logging.warning("OpenAI APITimeout Error: OpenAI Timeout")
-                await asyncio.sleep(10)
-            except openai.error.ServiceUnavailableError as e:
-                logging.warning(f"OpenAI service unavailable error: {e}")
-                await asyncio.sleep(10)
-            except openai.error.APIError as e:
-                logging.warning(f"OpenAI API error: {e}")
+            except tuple(ERROR_ERRORS_TO_MESSAGES.keys()) as e:
+                if isinstance(e, (error.ServiceUnavailableError, error.APIError)):
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)].format(e=e))
+                elif isinstance(e, error.InvalidRequestError):
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)])
+                    return {
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": "Invalid Request: Prompt was filtered"
+                                }
+                            }
+                        ]
+                    }
+                else:
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)])
                 await asyncio.sleep(10)
         return {"choices": [{"message": {"content": ""}}]}
 
@@ -70,6 +69,7 @@ async def generate_from_openai_completion(
     model_config: lm_config.LMConfig,
     temperature: float,
     max_tokens: int,
+    n: int,
     top_p: float,
     requests_per_minute: int = 150,
 ) -> list[str]:
@@ -80,6 +80,7 @@ async def generate_from_openai_completion(
         model_config: Model configuration.
         temperature: Temperature to use.
         max_tokens: Maximum number of tokens to generate.
+        n: Number of completions to generate for each API call.
         top_p: Top p to use.
         requests_per_minute: Number of requests per minute to allow.
 
@@ -99,6 +100,7 @@ async def generate_from_openai_completion(
             prompt=prompt,
             temperature=temperature,
             max_tokens=max_tokens,
+            n=n,
             top_p=top_p,
             limiter=limiter,
         )
@@ -115,9 +117,11 @@ async def _throttled_openai_chat_completion_acreate(
     messages: list[dict[str, str]],
     temperature: float,
     max_tokens: int,
+    n: int,
     top_p: float,
     limiter: aiolimiter.AsyncLimiter,
 ) -> dict[str, Any]:
+    # This function is modified from https://github.com/zeno-ml/zeno-build/blob/main/zeno_build/models/providers/openai_utils.py # noqa E501
     async with limiter:
         for _ in range(3):
             try:
@@ -126,36 +130,25 @@ async def _throttled_openai_chat_completion_acreate(
                     messages=messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    n=n,
                     top_p=top_p,
                 )
-            except openai.error.RateLimitError:
-                logging.warning(
-                    "OpenAI API rate limit exceeded. Sleeping for 10 seconds."
-                )
-                await asyncio.sleep(10)
-            except asyncio.exceptions.TimeoutError:
-                logging.warning("OpenAI API timeout. Sleeping for 10 seconds.")
-                await asyncio.sleep(10)
-            except openai.error.InvalidRequestError:
-                logging.warning("OpenAI API Invalid Request: Prompt was filtered")
-                return {
-                    "choices": [
-                        {"message": {"content": "Invalid Request: Prompt was filtered"}}
-                    ]
-                }
-            except openai.error.APIConnectionError:
-                logging.warning(
-                    "OpenAI API Connection Error: Error Communicating with OpenAI"
-                )
-                await asyncio.sleep(10)
-            except openai.error.Timeout:
-                logging.warning("OpenAI APITimeout Error: OpenAI Timeout")
-                await asyncio.sleep(10)
-            except openai.error.ServiceUnavailableError as e:
-                logging.warning(f"OpenAI service unavailable error: {e}")
-                await asyncio.sleep(10)
-            except openai.error.APIError as e:
-                logging.warning(f"OpenAI API error: {e}")
+            except tuple(ERROR_ERRORS_TO_MESSAGES.keys()) as e:
+                if isinstance(e, (error.ServiceUnavailableError, error.APIError)):
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)].format(e=e))
+                elif isinstance(e, error.InvalidRequestError):
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)])
+                    return {
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": "Invalid Request: Prompt was filtered"
+                                }
+                            }
+                        ]
+                    }
+                else:
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)])
                 await asyncio.sleep(10)
         return {"choices": [{"message": {"content": ""}}]}
 
@@ -166,6 +159,7 @@ async def generate_from_openai_chat_completion(
     model_config: lm_config.LMConfig,
     temperature: float,
     max_tokens: int,
+    n: int,
     top_p: float,
     context_length: int,
     requests_per_minute: int = 150,
@@ -178,6 +172,7 @@ async def generate_from_openai_chat_completion(
         model_config: Model configuration.
         temperature: Temperature to use.
         max_tokens: Maximum number of tokens to generate.
+        n: Number of responses to generate for each API call.
         top_p: Top p to use.
         context_length: Length of context to use.
         requests_per_minute: Number of requests per minute to allow.
@@ -200,6 +195,7 @@ async def generate_from_openai_chat_completion(
             ),
             temperature=temperature,
             max_tokens=max_tokens,
+            n=n,
             top_p=top_p,
             limiter=limiter,
         )

--- a/zeno_build/models/text_generate.py
+++ b/zeno_build/models/text_generate.py
@@ -51,6 +51,7 @@ def generate_from_text_prompt(
             top_p,
         )
     elif model_config.provider == "openai":
+        response_per_api_call = 1
         prompts = [replace_variables(prompt_template, vars) for vars in variables]
         return asyncio.run(
             generate_from_openai_completion(
@@ -58,6 +59,7 @@ def generate_from_text_prompt(
                 model_config,
                 temperature,
                 max_tokens,
+                response_per_api_call,
                 top_p,
                 requests_per_minute,
             )
@@ -82,6 +84,7 @@ def generate_from_text_prompt(
                 temperature=temperature,
                 max_tokens=max_tokens,
                 top_p=top_p,
+                n=1,
                 context_length=1,
                 requests_per_minute=requests_per_minute,
             )


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

1. I create `ERROR_ERRORS_TO_MESSAGES` to make the error handling clearer for `_throttled_openai_completion_acreate` and `_throttled_openai_chat_completion_acreate`.
2. There is no `TimeoutError` in `openai.error`, so I delete it.
3. I add a new parameter `n` for both completion, which is the number of responses to generate for each API call.

# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- https://github.com/zeno-ml/zeno-build/issues/169
- https://platform.openai.com/docs/api-reference/chat/create

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- This one works fine. Sorry for the previous one. I don't know why it's so strange.