### PR TITLE
Change default experiments for chatbot example

### DIFF
--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
         "--experiments",
         type=str,
         nargs="+",
-        default=["exhaustive"],
+        default=["model", "prompt", "temperature", "context_length"],
         help="The experiments to run.",
     )
     parser.add_argument(


### PR DESCRIPTION
# Description

By default, the chatbot example ran the "exhaustive" experimental setting, which results in tons of experiments being run. This PR reverts to running only the experiments that are included in the chatbot report by default, which seems like a reasonable setting.

# Blocked by

- NA
