### PR TITLE
add multiple generate functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ and new functionality for the core `zeno_build` library. If this is of interest
 to you, please click through to our [contributing doc](contributing.md) doc to
 learn more.
 
-## CITATION 
-To cite [GPT-MT report](examples/analysis_gpt_mt/README.md), please use the following BibTeX/APA entry.
+## CITATION
 
-**BibTeX**
+To cite [GPT-MT report](examples/analysis_gpt_mt/README.md), please use the
+following BibTeX/APA entry.
+
+### BibTeX
 
 ```bibtex
 @misc{Neubig_Zeno_GPT_Machine_2023,
@@ -91,11 +93,12 @@ To cite [GPT-MT report](examples/analysis_gpt_mt/README.md), please use the foll
   year = {2023}
 }
 ```
-**APA**
-```bibtex 
+
+### APA
+
+```bibtex
 Neubig, G., & He, Z. (2023). Zeno GPT Machine Translation Report
 ```
-
 
 ## Get in Touch
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,39 @@
+from zeno_build.models.lm_config import LMConfig
+from zeno_build.models.text_generate import generate_from_text_prompt, multiple_generate_from_text_prompt
+
+model = "gpt-3.5-turbo"
+model_provider = {"gpt-3.5-turbo": "openai_chat"}
+lm_config = LMConfig(provider=model_provider[model], model=model)
+prompt_templates = {
+    "openai_chat": ("Please rephrase this in the style of Donald Trump: {{text}}")
+}
+
+texts = [
+    "With Donald Trump skipping the first 2024 Republican presidential primary debate, brawled for second-place status Wednesday night.",
+    "Vivek Ramaswamy, the 38-year-old entrepreneur and first-time candidate, was the central figure for much of the night.",
+]
+
+predictions = multiple_generate_from_text_prompt(
+    [{"text": x} for x in texts],
+    prompt_template=prompt_templates[lm_config.provider],
+    model_config=lm_config,
+    temperature=1,
+    max_tokens=50,
+    top_p=1.0,
+    num_responses=5,
+    requests_per_minute=100,
+)
+
+print(predictions)
+
+single_predictions = generate_from_text_prompt(
+    [{"text": x} for x in texts],
+    prompt_template=prompt_templates[lm_config.provider],
+    model_config=lm_config,
+    temperature=1,
+    max_tokens=50,
+    top_p=1.0,
+    requests_per_minute=100,
+)
+
+print(single_predictions)

--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -35,7 +35,6 @@ def generate_from_chat_prompt(
     max_tokens: int,
     top_p: float,
     context_length: int,
-    num_responses: int = 1,
     requests_per_minute: int = 150,
 ) -> list[str]:
     """Generate from a list of chat-style prompts.
@@ -53,39 +52,26 @@ def generate_from_chat_prompt(
     Returns:
         The generated text.
     """
-    print(
-        f"Generating with {prompt_template=}, {model_config.model=}, "
-        f"{temperature=}, {max_tokens=}, {top_p=}, {context_length=}..."
-    )
-    if model_config.provider == "openai":
-        return asyncio.run(
-            generate_from_openai_completion(
-                _contexts_to_prompts(
-                    full_contexts, prompt_template, model_config, context_length
-                ),
-                model_config,
-                temperature,
-                max_tokens,
-                num_responses,
-                top_p,
-                requests_per_minute,
-            )
-        )
-    elif model_config.provider == "openai_chat":
-        return asyncio.run(
-            generate_from_openai_chat_completion(
+    if model_config.provider == "openai" or model_config.provider == "openai_chat":
+        return [
+            x[0]
+            for x in multiple_generate_from_chat_prompt(
                 full_contexts,
                 prompt_template,
                 model_config,
                 temperature,
                 max_tokens,
-                num_responses,
                 top_p,
                 context_length,
-                requests_per_minute,
+                num_responses=1,
+                requests_per_minute=150,
             )
-        )
-    elif model_config.provider == "cohere":
+        ]
+    print(
+        f"Generating with {prompt_template=}, {model_config.model=}, "
+        f"{temperature=}, {max_tokens=}, {top_p=}, {context_length=}..."
+    )
+    if model_config.provider == "cohere":
         return asyncio.run(
             generate_from_cohere(
                 _contexts_to_prompts(
@@ -117,6 +103,69 @@ def generate_from_chat_prompt(
             temperature,
             max_tokens,
             top_p,
+        )
+    else:
+        raise ValueError("Unknown provider, but you can add your own!")
+
+
+def multiple_generate_from_chat_prompt(
+    full_contexts: list[chat_prompt.ChatMessages],
+    prompt_template: chat_prompt.ChatMessages,
+    model_config: lm_config.LMConfig,
+    temperature: float,
+    max_tokens: int,
+    top_p: float,
+    context_length: int,
+    num_responses: int,
+    requests_per_minute: int = 150,
+) -> list[list[str]]:
+    """Generate from a list of chat-style prompts.
+
+    Args:
+        variables: The variables to be replaced in the prompt template.
+        prompt_template: The template for the prompt.
+        api_based_model_config: The API-based model configuration.
+        temperature: The temperature to use.
+        max_tokens: The maximum number of tokens to generate.
+        top_p: The top p value to use.
+        context_length: The length of the context to use.
+        num_responses: The number of responses to generate
+        requests_per_minute: Limit on the number of OpenAI requests per minute
+
+    Returns:
+        The generated text.
+    """
+    print(
+        f"Generating with {prompt_template=}, {model_config.model=}, "
+        f"{temperature=}, {max_tokens=}, {top_p=}, {context_length=}, {num_responses=}..."
+    )
+    if model_config.provider == "openai":
+        return asyncio.run(
+            generate_from_openai_completion(
+                _contexts_to_prompts(
+                    full_contexts, prompt_template, model_config, context_length
+                ),
+                model_config,
+                temperature,
+                max_tokens,
+                top_p,
+                num_responses,
+                requests_per_minute,
+            )
+        )
+    elif model_config.provider == "openai_chat":
+        return asyncio.run(
+            generate_from_openai_chat_completion(
+                full_contexts,
+                prompt_template,
+                model_config,
+                temperature,
+                max_tokens,
+                top_p,
+                context_length,
+                num_responses,
+                requests_per_minute,
+            )
         )
     else:
         raise ValueError("Unknown provider, but you can add your own!")

--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -35,6 +35,7 @@ def generate_from_chat_prompt(
     max_tokens: int,
     top_p: float,
     context_length: int,
+    num_responses: int = 1,
     requests_per_minute: int = 150,
 ) -> list[str]:
     """Generate from a list of chat-style prompts.
@@ -57,7 +58,6 @@ def generate_from_chat_prompt(
         f"{temperature=}, {max_tokens=}, {top_p=}, {context_length=}..."
     )
     if model_config.provider == "openai":
-        response_per_api_call = 1
         return asyncio.run(
             generate_from_openai_completion(
                 _contexts_to_prompts(
@@ -66,13 +66,12 @@ def generate_from_chat_prompt(
                 model_config,
                 temperature,
                 max_tokens,
-                response_per_api_call,
+                num_responses,
                 top_p,
                 requests_per_minute,
             )
         )
     elif model_config.provider == "openai_chat":
-        response_per_api_call = 1
         return asyncio.run(
             generate_from_openai_chat_completion(
                 full_contexts,
@@ -80,7 +79,7 @@ def generate_from_chat_prompt(
                 model_config,
                 temperature,
                 max_tokens,
-                response_per_api_call,
+                num_responses,
                 top_p,
                 context_length,
                 requests_per_minute,

--- a/zeno_build/models/text_generate.py
+++ b/zeno_build/models/text_generate.py
@@ -20,8 +20,8 @@ def generate_from_text_prompt(
     model_config: lm_config.LMConfig,
     temperature: float,
     max_tokens: int,
-    num_responses: int,
     top_p: float,
+    num_responses: int = 1,
     requests_per_minute: int = 150,
 ) -> list[str]:
     """Generate from a textual prompt.


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

Add "multiple generate" versions of the generate functions in `text_generate` and `chat_generate` to support > 1 number of responses. Returns a list of list of strings, where each index of the outer list corresponds to a prompt.

# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- Foo
- Bar
- Baz

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
- (or link to PRs)
