### PR TITLE
Adding support for Anthropic, Palm, AI21, Aleph Alpha, TogetherAI,

### DIFF
--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -1,6 +1,8 @@
 """Tools to generate from prompts."""
 import asyncio
 
+import nest_asyncio
+
 from zeno_build.models import lm_config
 from zeno_build.models.providers.cohere_utils import generate_from_cohere
 from zeno_build.models.providers.huggingface_utils import generate_from_huggingface
@@ -11,6 +13,8 @@ from zeno_build.models.providers.openai_utils import (
 )
 from zeno_build.models.providers.vllm_utils import generate_from_vllm
 from zeno_build.prompts import chat_prompt
+
+nest_asyncio.apply()
 
 
 def _contexts_to_prompts(
@@ -53,7 +57,7 @@ def generate_from_chat_prompt(
     Returns:
         The generated text.
     """
-    if model_config.provider == "openai" or model_config.provider == "openai_chat":
+    if model_config.provider in ("openai", "openai_chat", "litellm"):
         return [
             x[0]
             for x in multiple_generate_from_chat_prompt(

--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -1,15 +1,13 @@
 """Tools to generate from prompts."""
 import asyncio
-import litellm
+
 from zeno_build.models import lm_config
 from zeno_build.models.providers.cohere_utils import generate_from_cohere
 from zeno_build.models.providers.huggingface_utils import generate_from_huggingface
+from zeno_build.models.providers.litellm_utils import generate_from_litellm_completion
 from zeno_build.models.providers.openai_utils import (
     generate_from_openai_chat_completion,
     generate_from_openai_completion,
-)
-from zeno_build.models.providers.litellm_utils import (
-    generate_from_litellm_chat_completion
 )
 from zeno_build.models.providers.vllm_utils import generate_from_vllm
 from zeno_build.prompts import chat_prompt
@@ -55,7 +53,7 @@ def generate_from_chat_prompt(
     Returns:
         The generated text.
     """
-    if model_config.provider == "openai" or model_config.provider == "openai_chat" or model_config.provider in litellm.provider_list:
+    if model_config.provider == "openai" or model_config.provider == "openai_chat":
         return [
             x[0]
             for x in multiple_generate_from_chat_prompt(
@@ -170,9 +168,9 @@ def multiple_generate_from_chat_prompt(
                 requests_per_minute,
             )
         )
-    elif model_config.provider in litellm.provider_list:
+    elif model_config.provider == "litellm":
         return asyncio.run(
-            generate_from_litellm_chat_completion(
+            generate_from_litellm_completion(
                 full_contexts,
                 prompt_template,
                 model_config,

--- a/zeno_build/models/chat_generate.py
+++ b/zeno_build/models/chat_generate.py
@@ -1,12 +1,15 @@
 """Tools to generate from prompts."""
 import asyncio
-
+import litellm
 from zeno_build.models import lm_config
 from zeno_build.models.providers.cohere_utils import generate_from_cohere
 from zeno_build.models.providers.huggingface_utils import generate_from_huggingface
 from zeno_build.models.providers.openai_utils import (
     generate_from_openai_chat_completion,
     generate_from_openai_completion,
+)
+from zeno_build.models.providers.litellm_utils import (
+    generate_from_litellm_chat_completion
 )
 from zeno_build.models.providers.vllm_utils import generate_from_vllm
 from zeno_build.prompts import chat_prompt
@@ -52,7 +55,7 @@ def generate_from_chat_prompt(
     Returns:
         The generated text.
     """
-    if model_config.provider == "openai" or model_config.provider == "openai_chat":
+    if model_config.provider == "openai" or model_config.provider == "openai_chat" or model_config.provider in litellm.provider_list:
         return [
             x[0]
             for x in multiple_generate_from_chat_prompt(
@@ -156,6 +159,20 @@ def multiple_generate_from_chat_prompt(
     elif model_config.provider == "openai_chat":
         return asyncio.run(
             generate_from_openai_chat_completion(
+                full_contexts,
+                prompt_template,
+                model_config,
+                temperature,
+                max_tokens,
+                top_p,
+                context_length,
+                num_responses,
+                requests_per_minute,
+            )
+        )
+    elif model_config.provider in litellm.provider_list:
+        return asyncio.run(
+            generate_from_litellm_chat_completion(
                 full_contexts,
                 prompt_template,
                 model_config,

--- a/zeno_build/models/providers/litellm_utils.py
+++ b/zeno_build/models/providers/litellm_utils.py
@@ -1,0 +1,113 @@
+"""Tools to generate from OpenAI prompts."""
+
+import asyncio
+import logging
+import os
+from typing import Any
+from litellm import completion, acompletion
+import aiolimiter
+import litellm
+from aiohttp import ClientSession
+from openai import error
+from tqdm.asyncio import tqdm_asyncio
+
+from zeno_build.models import lm_config
+from zeno_build.prompts import chat_prompt
+
+ERROR_ERRORS_TO_MESSAGES = {
+    error.InvalidRequestError: "OpenAI API Invalid Request: Prompt was filtered",
+    error.RateLimitError: "OpenAI API rate limit exceeded. Sleeping for 10 seconds.",
+    error.APIConnectionError: "OpenAI API Connection Error: Error Communicating with OpenAI",  # noqa E501
+    error.Timeout: "OpenAI APITimeout Error: OpenAI Timeout",
+    error.ServiceUnavailableError: "OpenAI service unavailable error: {e}",
+    error.APIError: "OpenAI API error: {e}",
+}
+
+async def _throttled_openai_chat_completion_acreate(
+    model: str,
+    messages: list[dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+    top_p: float,
+    n: int,
+    limiter: aiolimiter.AsyncLimiter,
+) -> dict[str, Any]:
+    async with limiter:
+        for _ in range(3):
+            try:
+                return await acompletion(
+                    model=model,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    top_p=top_p,
+                    n=n,
+                )
+            except tuple(ERROR_ERRORS_TO_MESSAGES.keys()) as e:
+                if isinstance(e, (error.ServiceUnavailableError, error.APIError)):
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)].format(e=e))
+                elif isinstance(e, error.InvalidRequestError):
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)])
+                    return {
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": "Invalid Request: Prompt was filtered"
+                                }
+                            }
+                        ]
+                    }
+                else:
+                    logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)])
+                await asyncio.sleep(10)
+        return {"choices": [{"message": {"content": ""}}]}
+
+
+async def generate_from_litellm_chat_completion(
+    full_contexts: list[chat_prompt.ChatMessages],
+    prompt_template: chat_prompt.ChatMessages,
+    model_config: lm_config.LMConfig,
+    temperature: float,
+    max_tokens: int,
+    top_p: float,
+    context_length: int,
+    n: int,
+    requests_per_minute: int = 150,
+) -> list[list[str]]:
+    """Generate from OpenAI Chat Completion API.
+
+    Args:
+        full_contexts: List of full contexts to generate from.
+        prompt_template: Prompt template to use.
+        model_config: Model configuration.
+        temperature: Temperature to use.
+        max_tokens: Maximum number of tokens to generate.
+        n: Number of responses to generate for each API call.
+        top_p: Top p to use.
+        context_length: Length of context to use.
+        requests_per_minute: Number of requests per minute to allow.
+
+    Returns:
+        List of generated responses.
+    """
+    limiter = aiolimiter.AsyncLimiter(requests_per_minute)
+    async_responses = [
+        _throttled_openai_chat_completion_acreate(
+            model=model_config.model,
+            messages=prompt_template.to_openai_chat_completion_messages(
+                full_context=full_context.limit_length(context_length),
+            ),
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            n=n,
+            limiter=limiter,
+        )
+        for full_context in full_contexts
+    ]
+    responses = await tqdm_asyncio.gather(*async_responses)
+    # Note: will never be none because it's set, but mypy doesn't know that.
+    all_responses = []
+    for x in responses:
+        all_responses.append([x["choices"][i]["message"]["content"] for i in range(n)])
+    return all_responses

--- a/zeno_build/models/providers/openai_utils.py
+++ b/zeno_build/models/providers/openai_utils.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 from typing import Any
-from litellm import completion, acompletion
+
 import aiolimiter
 import openai
 from aiohttp import ClientSession
@@ -36,7 +36,7 @@ async def _throttled_openai_completion_acreate(
     async with limiter:
         for _ in range(3):
             try:
-                return await acompletion(
+                return await openai.Completion.acreate(
                     model=engine,
                     prompt=prompt,
                     temperature=temperature,

--- a/zeno_build/models/providers/openai_utils.py
+++ b/zeno_build/models/providers/openai_utils.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 from typing import Any
-
+from litellm import completion, acompletion
 import aiolimiter
 import openai
 from aiohttp import ClientSession
@@ -36,8 +36,8 @@ async def _throttled_openai_completion_acreate(
     async with limiter:
         for _ in range(3):
             try:
-                return await openai.Completion.acreate(
-                    engine=engine,
+                return await acompletion(
+                    model=engine,
                     prompt=prompt,
                     temperature=temperature,
                     max_tokens=max_tokens,


### PR DESCRIPTION
Hi @lindiatjuatja, 

Saw you support OpenAI, Azure, Cohere and HF.  I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

I added support for the providers listed above by replacing the chatcompletion.acreate with acompletion. The code is pretty similar to the OpenAI class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.

Happy to add additional tests / update documentation, if the initial PR looks good to you.